### PR TITLE
Add support for custom heading slugs

### DIFF
--- a/iles.config.ts
+++ b/iles.config.ts
@@ -2,6 +2,8 @@ import headings from "@islands/headings";
 import icons from "@islands/icons";
 import prism from "@islands/prism";
 import { RawPageMatter, defineConfig } from "iles";
+import rehypeExternalLinks from "rehype-external-links";
+import rehypeSlugCustomId from "rehype-slug-custom-id";
 
 import site from "./src/site";
 
@@ -26,7 +28,10 @@ export default defineConfig({
     }
   },
   markdown: {
-    rehypePlugins: ["rehype-external-links"],
+    rehypePlugins: [
+      rehypeExternalLinks,
+      [rehypeSlugCustomId, { enableCustomId: true }],
+    ],
   },
   modules: [headings(), icons(), prism()],
   prettyUrls: !isPreview, // Disable in preview mode

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "prettier-plugin-tailwindcss": "^0.1.13",
     "prism-themes": "^1.9.0",
     "rehype-external-links": "^2.0.1",
+    "rehype-slug-custom-id": "^1.1.0",
     "tailwindcss": "^3.2.4",
     "vite-plugin-tailwindcss": "0.0.0-0",
     "vue-tsc": "^1.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ specifiers:
   prettier-plugin-tailwindcss: ^0.1.13
   prism-themes: ^1.9.0
   rehype-external-links: ^2.0.1
+  rehype-slug-custom-id: ^1.1.0
   tailwindcss: ^3.2.4
   vite-plugin-tailwindcss: 0.0.0-0
   vue-tsc: ^1.0.9
@@ -53,6 +54,7 @@ devDependencies:
   prettier-plugin-tailwindcss: 0.1.13_prettier@2.7.1
   prism-themes: 1.9.0
   rehype-external-links: 2.0.1
+  rehype-slug-custom-id: 1.1.0
   tailwindcss: 3.2.4_postcss@8.4.19
   vite-plugin-tailwindcss: 0.0.0-0_vite@2.9.15
   vue-tsc: 1.0.9_typescript@4.9.3
@@ -1470,6 +1472,10 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /github-slugger/1.5.0:
+    resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
+    dev: true
+
   /glob-parent/5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1531,6 +1537,10 @@ packages:
 
   /hash-sum/2.0.0:
     resolution: {integrity: sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==}
+    dev: true
+
+  /hast-util-has-property/2.0.0:
+    resolution: {integrity: sha512-4Qf++8o5v14us4Muv3HRj+Er6wTNGA/N9uCaZMty4JWvyFKLdhULrv4KE1b65AthsSO9TXSZnjuxS8ecIyhb0w==}
     dev: true
 
   /hast-util-heading-rank/2.1.0:
@@ -1886,6 +1896,10 @@ packages:
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: true
+
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
 
   /longest-streak/3.0.1:
@@ -2632,6 +2646,19 @@ packages:
       extend: 3.0.2
       is-absolute-url: 4.0.1
       space-separated-tokens: 2.0.1
+      unified: 10.1.2
+      unist-util-visit: 4.1.1
+    dev: true
+
+  /rehype-slug-custom-id/1.1.0:
+    resolution: {integrity: sha512-lLdTHGd7u5bOXRDnD78/VHrVZsG63nN6lZUuQgcuupGt1+v+uDW7pCeQS0cvptRcZPYzg8B+0bf8sUiMBKsjZw==}
+    dependencies:
+      '@types/hast': 2.3.4
+      github-slugger: 1.5.0
+      hast-util-has-property: 2.0.0
+      hast-util-heading-rank: 2.1.0
+      hast-util-to-string: 2.0.0
+      lodash: 4.17.21
       unified: 10.1.2
       unist-util-visit: 4.1.1
     dev: true


### PR DESCRIPTION
This gives us a free hand to assign whichever links we want to headings. So if we have a heading like "This is a heading right here" we won't be stuck with a slug like `this-is-a-heading-right-here` and could assign it `foo` or whatever.
