### PR TITLE
Fix z-index issue for code samples

### DIFF
--- a/src/components/layout/Navbar.vue
+++ b/src/components/layout/Navbar.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="sticky top-0 border-b-2 border-light-gray bg-white/75 py-2 backdrop-blur dark:border-b-gray dark:bg-dark md:py-2.5 lg:py-3"
+    class="sticky top-0 z-10 border-b-2 border-light-gray bg-white/75 py-2 backdrop-blur dark:border-b-gray dark:bg-dark md:py-2.5 lg:py-3"
   >
     <HorizontalContainer>
       <div class="flex items-center justify-between">

--- a/src/plugins/code.ts
+++ b/src/plugins/code.ts
@@ -55,7 +55,7 @@ const highlightCode = (
   const dataLang = lang === "text" ? "" : lang;
   const blockMeta = parseMeta(meta);
   const innerHtml = [
-    `<pre class="${cls}">`,
+    `<pre class="${cls} z-0">`,
     blockMeta.filename !== undefined &&
       `<span class="absolute top-2 right-3 text-sm">${blockMeta.filename}</span>`,
     `<code>${code}</code></pre>`,


### PR DESCRIPTION
For some reason, adding the `relative` class to code blocks makes them appear on top of the navbar and navbar dropdowns. This PR adds explicit z-index settings (`z-0` to the code blocks and `z-10` to the navbar) that address this. We may want to make this more elegant in the future but this fixes the pain point for now.
