### PR TITLE
Use kernel.org instead of linux.org

### DIFF
--- a/.htmltest.external.yml
+++ b/.htmltest.external.yml
@@ -1,4 +1,4 @@
 CheckInternal: false
 DirectoryPath: dist
-IgnoreURLs: ["https://www.linux.org"]
+IgnoreURLs: ["https://www.kernel.org/"]
 CheckScripts: false

--- a/src/pages/concepts/nixos.mdx
+++ b/src/pages/concepts/nixos.mdx
@@ -1,7 +1,7 @@
 ---
 title: NixOS
 snippet: |
-  A [Linux](https://linux.org) distribution built on the [Nix](/concepts/nix) package manager and guided by Nix's core principles
+  A [Linux](https://www.kernel.org/) distribution built on the [Nix](/concepts/nix) package manager and guided by Nix's core principles
 related: ["nix", "nix-language", "nixpkgs"]
 externalSources: [
   {

--- a/src/pages/start/learn-more.mdx
+++ b/src/pages/start/learn-more.mdx
@@ -155,7 +155,7 @@ Because Nix development environments are both cross platform and fully [reproduc
 [gpg]: https://gnupg.org
 [home]: https://github.com/nix-community/home-manager
 [install]: /start/install
-[linux]: https://linux.org
+[linux]: https://www.kernel.org/
 [nix]: /concepts/nix
 [nixos]: /concepts/nixos
 [oci]: https://opencontainers.org


### PR DESCRIPTION
Linux.org is probably not the site we want to link to. It seems to be a forum/marketing site instead of the Linux kernel site (kernel.org), an official site of the Linux foundation, or a link to something defining Linux.