### PR TITLE
Remove 'left us little choice'

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -4,7 +4,7 @@ description: What it is, why we made it, and how it fits into the [Nix](/concept
 layout: plain
 ---
 
-[**Zero to Nix**](/) is a highly opinionated learning resource for [Nix] created by Determinate Systems. We created Zero to Nix for two reasons:
+[**Zero to Nix**](/) is a highly opinionated learning resource for [Nix] created by Determinate Systems. We believe Zero to Nix fills a major gap for two reasons:
 
 1. We find most of the existing [Nix] documentation to be difficult to navigate for beginners.
   Sources like the [Nixpkgs manual][manual], the [official website][nix], [Nix Pills][pills], and semi-official sources like [nix.dev] are all great once you have a strong sense of how Nix works and what it provides.
@@ -12,8 +12,6 @@ layout: plain
   But together they can be daunting to the uninitiated, and we wanted to provide a gentle "front end" to the official documentation sources.
 1. We strongly believe that [flakes] are the future of Nix and that people onboarding into Nix should use them from the get-go.
   But flakes are currently marked as an experimental feature of Nix and are thus not discussed in any of the official Nix documentation sources (with the exception of the [Wiki entry][wiki] for flakes).
-
-These things together left us little choice but to proceed on our own outside of official channels.
 
 ## What's opinionated about Zero to Nix
 


### PR DESCRIPTION
The sentence 'These things together left us little choice but to proceed on our own outside of official channels' might be interpreted as combative and isn't really needed.