### PR TITLE
PageSurveyButtons: pass the reaction up to the parent

### DIFF
--- a/src/components/layout/PageSurveyButtons.vue
+++ b/src/components/layout/PageSurveyButtons.vue
@@ -28,6 +28,6 @@ const emit = defineEmits(["complete"]);
 
 const submitResponse = (reaction: Reaction) => {
   posthog.capture("page_review", { reaction });
-  emit("complete");
+  emit("complete", reaction);
 };
 </script>


### PR DESCRIPTION
This lets the typed feedback form be customized based on reply, and attaches the reaction to the posthog feedback event.