### PR TITLE
Shell: use `template` value instead of `lang` in dir names

### DIFF
--- a/src/components/mdx/code/Shell.vue
+++ b/src/components/mdx/code/Shell.vue
@@ -3,7 +3,7 @@
   <div class="language-shell" data-lang="shell">
     <pre
       class="language-shell"
-    ><code><span class="token function">mkdir</span> {{ `nix-${lang}` }} <span class="token operator">&amp;&amp;</span> <span class="token builtin class-name">cd</span> {{  `nix-${lang}` }}
+    ><code><span class="token function">mkdir</span> {{ `nix-${template}` }} <span class="token operator">&amp;&amp;</span> <span class="token builtin class-name">cd</span> {{  `nix-${template}` }}
 nix flake init <span class="token parameter variable">--template</span> <span class="token string">"github:DeterminateSystems/templates#{{ template }}"</span></code></pre>
   </div>
 </template>


### PR DESCRIPTION
This makes it unique per-template, instead of per-language. Otherwise, a user might balk at seeing the same directory used twice with `nix flake init`.