### PR TITLE
git status -> git help

### DIFF
--- a/src/pages/start/nix-develop.mdx
+++ b/src/pages/start/nix-develop.mdx
@@ -69,7 +69,7 @@ The `nix develop` command provides a `--command` (or `-c`) flag that you can use
 Here are some examples for the environment we used earlier:
 
 ```shell
-nix develop "github:DeterminateSystems/templates#example" --command git status
+nix develop "github:DeterminateSystems/templates#example" --command git help
 nix develop "github:DeterminateSystems/templates#example" --command curl https://example.com
 ```
 


### PR DESCRIPTION
`git status` tends to fail because usually the user is not in a git-managed directory.