### PR TITLE
Tone down the novelty of installing Nix

### DIFF
--- a/src/pages/start/install.mdx
+++ b/src/pages/start/install.mdx
@@ -21,7 +21,7 @@ curl -L https://install.determinate.systems/nix | sh -s -- install
 
 <Admonition title="Why aren't we using the official Nix installation script here?" kind="info" id="why-nix-installer" client:load>
 We believe that Nix Installer provides a smoother experience for people who are new to Nix than the [official Nix installation script][official].
-Unlike many tools, Nix needs to make several bold changes to your system in order to work properly, such as creating a new root volume in the `/nix` directory, configuring your shell profile, and creating several new system users and groups.
+Unlike many tools, Nix needs to make several changes to your system in order to work properly, such as creating a new `/nix` directory, configuring your shell profile, and creating several new system users and groups.
 
 Nix Installer improves on the official Nix installation script by enabling you to undo, with a single command, all of the system changes introduced by Nix Installer's installation process.
 It also installs Nix with [Nix flakes][flakes] enabled, while the official installer requires you to enable flakes manually.


### PR DESCRIPTION
I'm not sure about this change, but Linux installers won't need a volume for `/nix`. RFC?