### PR TITLE
Remove derivations concept from parts of the quick start

### DIFF
--- a/src/pages/concepts/nix-language.mdx
+++ b/src/pages/concepts/nix-language.mdx
@@ -113,4 +113,11 @@ The `rec` keyword allows the attribute set to reference itself.
 
 For a more detailed breakdown of syntax, check out the [Nix language](https://nixos.org/manual/nix/stable/language) manual section.
 
+## Derivations
+
+One thing that sets Nix apart from other programming languages&mdash;and makes it much more than just a configuration language&mdash;is the `derivation` function.
+This is a built-in function that you use to define the build process for packages.
+See the [derivations] concept doc for more info.
+
 [declarative]: /concepts/declarative
+[derivations]: /concepts/derivations

--- a/src/pages/start/nix-build-nixpkgs.mdx
+++ b/src/pages/start/nix-build-nixpkgs.mdx
@@ -33,8 +33,8 @@ You should see a path like this (it's likely to be a bit different on your machi
 What's happened here is that the Nix CLI has:
 
 * Downloaded the Nix code in [Nixpkgs]
-* Found the [derivation][derivations] with the name `bat` (code [here][nixpkgs-bat])
-* Used the build instructions in the derivation to build the [package][packages]
+* Found a package definition with the name `bat` (code [here][nixpkgs-bat])
+* Used the build instructions for `bat` to build the [package][packages]
 * Stored the result in the [Nix store][store] using Nix's hash-based path system
 {/* TODO: add substitution here and link to future caching doc */}
 
@@ -49,7 +49,7 @@ You've built and run a package using Nix.
 
 ## Build a package written in `$LANGUAGE` \{#language-specific}
 
-One of the great things about Nix is that [derivations] are extremely flexible, which enables you to create packages for things written in just about any programming language. In this section, we'll explore that by building and running packages for tools written in a variety of languages. Select one below to see some examples:
+One of the great things about Nix is that package builds are extremely flexible, which enables you to create packages for things written in just about any programming language. In this section, we'll explore that by building and running packages for tools written in a variety of languages. Select one below to see some examples:
 
 <Languages client:load />
 
@@ -123,7 +123,6 @@ Upstreaming your packages to Nixpkgs is always an option, but it's good to bear 
 [bat]: https://github.com/sharkdp/bat
 [cat]: https://en.wikipedia.org/wiki/Cat_(Unix)
 [cmake]: https://cmake.org
-[derivations]: /concepts/derivations
 [flake]: /concepts/flakes
 [hm]: https://github.com/nix-community/home-manager
 [install]: /start/install

--- a/src/pages/start/nix-run.mdx
+++ b/src/pages/start/nix-run.mdx
@@ -35,7 +35,7 @@ What happened here? The [Nix] CLI did a few things:
 * It ran the executable at `bin/ponysay` from the `ponysay` package.
 
 In Nix, every program is part of a [package][packages].
-Packages are built using special functions in the [Nix language][lang] called [derivations].
+Packages are built using the [Nix language][derivations].
 The `ponysay` package has a single program (also called `ponysay`) but packages can contain multiple programs as well as man pages, configuration files, and more.
 The [`ffmpeg`][ffmpeg-pkg] package, for example, provides both [ffmpeg] and [ffprobe].
 
@@ -52,11 +52,10 @@ You're now ready to explore Nix development environments.
 
 [blog]: https://determinate.systems/posts
 [cache]: /concepts/caching
-[derivations]: /concepts/derivations
+[derivations]: /concepts/nix-language#derivations
 [ffmpeg]: https://ffmpeg.org
 [ffmpeg-pkg]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/ffmpeg/generic.nix
 [ffprobe]: https://ffmpeg.org/ffprobe.html
-[lang]: /concepts/nix-language
 [nix]: /concepts/nix
 [nix-installer]: /concepts/nix-installer
 [nix-run]: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-run


### PR DESCRIPTION
At least one user study has indicated that this is too advanced a concept to mention early on in the quick start.
