### PR TITLE
Install pip from python3Packages

### DIFF
--- a/src/pages/start/3.nix-build-nixpkgs.mdx
+++ b/src/pages/start/3.nix-build-nixpkgs.mdx
@@ -83,7 +83,7 @@ If you run `ls result/bin` you'll notice that the package also includes [npx].
 Let's build and run [pip]:
 
 ```shell
-nix build "nixpkgs#pythonPackages.pip"
+nix build "nixpkgs#python3Packages.pip"
 ./result/bin/pip --help
 ```
 </SpecificLanguage>


### PR DESCRIPTION
This avoids Python2 EOL messages being displayed.