### PR TITLE
shell prompt: the nix:example bit should be a prefix

### DIFF
--- a/src/pages/start/4.nix-develop.mdx
+++ b/src/pages/start/4.nix-develop.mdx
@@ -26,10 +26,10 @@ This is in contrast to most [package managers][pkg], which install things more q
 Future `nix develop` invocations should be much faster, as Nix doesn't need to build the packages again.
 </Admonition>
 
-You should be greeted by a new shell prompt:
+You should be greeted by a new shell prompt, something like this:
 
 ```shell
-(nix:example)
+(nix:example) bash-5.1$
 ```
 
 :rocket: **Success**!


### PR DESCRIPTION
...and it may not look exactly like ours, so let the reader know it may be different.