### PR TITLE
Fix URL typo on Learn More page

### DIFF
--- a/src/pages/start/9.learn-more.mdx
+++ b/src/pages/start/9.learn-more.mdx
@@ -97,7 +97,7 @@ Another powerful Nix feature is that you can use it to build [OCI]-compliant con
   },
   {
     title: "Declarative management of dotfiles with Nix and Home Manager",
-    href: "https://bekk.christmas/post/2021/16/dotfiles-with-nix-and-home-managerg",
+    href: "https://bekk.christmas/post/2021/16/dotfiles-with-nix-and-home-manager",
     source: {
       title: "Bekk Christmas' blog",
       href: "https://bekk.christmas"


### PR DESCRIPTION
Found an extraneous "g" on the URL for the "Declarative management of dotfiles with Nix and Home Manager" link.