### PR TITLE
flake: ci script should fail on error

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,8 @@
 
           # Run this to see if CI will pass
           (writeScriptBin "ci" ''
+            set -e
+
             build-ci
             check-internal-links
             lint-style

--- a/src/pages/start/5.nix-search.mdx
+++ b/src/pages/start/5.nix-search.mdx
@@ -59,7 +59,7 @@ This can be useful if you want to parse the output using a tool like [jq].
 
 The web interface at [search.nixos.org][search] has a few advantages over the [`nix search`](#nix-search-command) command:
 
-* It enables you to select a [release channel][release] for [Nixpkgs], such as [22.11] and [unstable]
+* It enables you to select a release channel for [Nixpkgs], such as [22.11] and [unstable]
 * It enables you to search across a range of [public flakes][public-flakes] beyond Nixpkgs (those flakes are listed [here][flakes-list])
 
 ## Exploring a flake with the `nix flake show` command \{#nix-flake-show}
@@ -108,7 +108,6 @@ The `cargo` package on a Linux machine is considered a *different package* from 
 [packages]: /concepts/packages
 [pkg]: /concepts/package-management
 [public-flakes]: https://search.nixos.org/flakes
-[release]: /concepts/nixpkgs#release-channels
 [search]: https://search.nixos.org
 [system-specific]: /concepts/system-specificity
 [unstable]: https://github.com/nixOS/nixpkgs/tree/nixpkgs-unstable


### PR DESCRIPTION
I noticed that there is a missing hash, and somehow CI didn't catch it; this is likely because even though it _was_ caught by one of the scripts `ci` runs, `ci` doesn't fail when it encounters an error.