### PR TITLE
test: don't make cache.nixos.org pubkey a secret

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,14 @@ jobs:
           eval "$(nix develop --command direnv export bash)"
           echo "$PATH" >> $GITHUB_PATH
       - name: Cachix setup
+        if: github.event.pull_request.head.repo.full_name == 'DeterminateSystems/zero-to-nix'
         run: |
           cachix authtoken ${{ secrets.CACHIX_AUTH_TOKEN }}
           cachix use ${{ secrets.CACHIX_CACHE }}
       - name: Run Nix CI suite
         run: ci
       - name: Push dev shell to Cachix
+        if: github.event.pull_request.head.repo.full_name == 'DeterminateSystems/zero-to-nix'
         run: |
           nix develop --profile zero-to-nix
           cachix push ${{ secrets.CACHIX_CACHE }} zero-to-nix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
             binary-caches = https://cache.nixos.org https://${{ secrets.CACHIX_CACHE }}.cachix.org
             trusted-substituters = https://cache.nixos.org https://${{ secrets.CACHIX_CACHE }}.cachix.org
             trusted-users = root runner
-            trusted-public-keys = ${{ secrets.CACHIX_TRUSTED_PUBLIC_KEY }} ${{ secrets.NIXOS_PUBLIC_KEY }}
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ secrets.CACHIX_TRUSTED_PUBLIC_KEY }}
       - name: direnv activate
         run: |
           nix develop --command direnv allow


### PR DESCRIPTION
This means that external contributors can actually have their CI run
without needing to rebuild the world (without this key, any hits from
cache.nixos.org will not be used due to a lack of a trusted signature).

---

PR from outside to validate that this does what we expect for external contributors.