### PR TITLE
Update to reflect the output for cpp

### DIFF
--- a/src/pages/start/6.dev-shell-flake.mdx
+++ b/src/pages/start/6.dev-shell-flake.mdx
@@ -46,7 +46,7 @@ type gcc
 You should see a (rather strange) path like this:
 
 ```shell
-/nix/store/nbrvvx1gyq3as3ghmjz62wlgd8f3zfpf-gcc-wrapper-11.3.0/bin/gcc
+gcc is /nix/store/nbrvvx1gyq3as3ghmjz62wlgd8f3zfpf-gcc-wrapper-11.3.0/bin/gcc
 ```
 </SpecificLanguage>
 <SpecificLanguage client:load lang="Haskell">


### PR DESCRIPTION
Bringing the output inline w/ the other languages and accurate with the output for `type gcc`