### PR TITLE
c++: pkg: fix incorrect description in example

### DIFF
--- a/nix/templates/pkg/cpp/flake.nix
+++ b/nix/templates/pkg/cpp/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Python example flake for Zero to Nix";
+  description = "C++ example flake for Zero to Nix";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";


### PR DESCRIPTION
Noticed this while going through the tutorial.

The description should say C++ instead of Python.