### PR TITLE
Fix python template using wrong binary name

### DIFF
--- a/nix/templates/pkg/python/setup.py
+++ b/nix/templates/pkg/python/setup.py
@@ -7,6 +7,6 @@ setup(
     version='0.1.0',
     py_modules=['hello'],
     entry_points={
-        'console_scripts': ['hello = hello:main']
+        'console_scripts': ['zero-to-nix-python = hello:main']
     },
 )


### PR DESCRIPTION
Fixes https://github.com/DeterminateSystems/zero-to-nix/issues/193.

---

You can validate with:

```
nix flake init --template "github:DeterminateSystems/zero-to-nix/fix-wrong-command#python-pkg"
nix build
./result/bin/zero-to-nix-python
```