### PR TITLE
Add non-curl-to-Bash installation option

### DIFF
--- a/src/assets/css/prose.css
+++ b/src/assets/css/prose.css
@@ -43,8 +43,7 @@
     p,
     .content,
     h2,
-    h3,
-    li {
+    h3 {
       code {
         @apply inline-code;
       }

--- a/src/pages/start/1.install.mdx
+++ b/src/pages/start/1.install.mdx
@@ -19,13 +19,16 @@ The best way to install Nix is to use [Nix installer][nix-installer], a tool fro
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
 ```
 
-If you have concerns about the "curl to Bash" approach you can examine the installation script [here][script] and use these steps instead:
+If you have concerns about the "curl to Bash" approach you have two options:
 
-```shell
-curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix > nix-installer.sh
-chmod +x nix-installer.sh
-./nix-installer.sh install
-```
+1. You can download a binary for the most recent version of Nix Installer directly from the [releases] page and run it.
+1. You can examine the installation script [here][script] then download and run it:
+
+  ```shell
+  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix > nix-installer.sh
+  chmod +x nix-installer.sh
+  ./nix-installer.sh install
+  ```
 
 <Admonition info title="Why aren't we using the official Nix installation script here?" id="why-nix-installer" client:load>
 We believe that Nix Installer provides a smoother experience for people who are new to Nix than the [official Nix installation script][official].
@@ -80,6 +83,7 @@ There are four main ways to do that:
 [nix-installer]: /concepts/nix-installer
 [official]: https://nixos.org/download
 [pr]: https://github.com/DeterminateSystems/zero-to-nix/pulls
+[releases]: https://github.com/DeterminateSystems/nix-installer/releases
 [repo]: https://github.com/DeterminateSystems/zero-to-nix
 [script]: https://raw.githubusercontent.com/DeterminateSystems/nix-installer/main/nix-installer.sh
 [start]: /start

--- a/src/pages/start/1.install.mdx
+++ b/src/pages/start/1.install.mdx
@@ -19,6 +19,14 @@ The best way to install Nix is to use [Nix installer][nix-installer], a tool fro
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
 ```
 
+If you have concerns about the "curl to Bash" approach you can examine the installation script [here][script] and use these steps instead:
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix > nix-installer.sh
+chmod +x nix-installer.sh
+./nix-installer.sh install
+```
+
 <Admonition info title="Why aren't we using the official Nix installation script here?" id="why-nix-installer" client:load>
 We believe that Nix Installer provides a smoother experience for people who are new to Nix than the [official Nix installation script][official].
 Unlike many tools, Nix needs to make several changes to your system in order to work properly, such as creating a new `/nix` directory, configuring your shell profile, and creating several new system users and groups.
@@ -73,6 +81,7 @@ There are four main ways to do that:
 [official]: https://nixos.org/download
 [pr]: https://github.com/DeterminateSystems/zero-to-nix/pulls
 [repo]: https://github.com/DeterminateSystems/zero-to-nix
+[script]: https://github.com/DeterminateSystems/nix-installer/blob/main/nix-installer.sh
 [start]: /start
 [store]: /concepts/nix-store
 [uninstall]: /start/uninstall

--- a/src/pages/start/1.install.mdx
+++ b/src/pages/start/1.install.mdx
@@ -81,7 +81,7 @@ There are four main ways to do that:
 [official]: https://nixos.org/download
 [pr]: https://github.com/DeterminateSystems/zero-to-nix/pulls
 [repo]: https://github.com/DeterminateSystems/zero-to-nix
-[script]: https://github.com/DeterminateSystems/nix-installer/blob/main/nix-installer.sh
+[script]: https://raw.githubusercontent.com/DeterminateSystems/nix-installer/main/nix-installer.sh
 [start]: /start
 [store]: /concepts/nix-store
 [uninstall]: /start/uninstall

--- a/src/pages/start/1.install.mdx
+++ b/src/pages/start/1.install.mdx
@@ -24,11 +24,11 @@ If you have concerns about the "curl to Bash" approach you have two options:
 1. You can download a binary for the most recent version of Nix Installer directly from the [releases] page and run it.
 1. You can examine the installation script [here][script] then download and run it:
 
-  ```shell
-  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix > nix-installer.sh
-  chmod +x nix-installer.sh
-  ./nix-installer.sh install
-  ```
+    ```shell
+    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix > nix-installer.sh
+    chmod +x nix-installer.sh
+    ./nix-installer.sh install
+    ```
 
 <Admonition info title="Why aren't we using the official Nix installation script here?" id="why-nix-installer" client:load>
 We believe that Nix Installer provides a smoother experience for people who are new to Nix than the [official Nix installation script][official].

--- a/vale/Vocab/Docs/accept.txt
+++ b/vale/Vocab/Docs/accept.txt
@@ -16,6 +16,7 @@ cargolock
 cachix
 changemeplz
 channable
+chmod
 ci
 clis
 cmake


### PR DESCRIPTION
I've seen concerns about "curl to Bash" in a few corners. This seems like a reasonable way to address those.