### PR TITLE
start/nix-run: `nixpkgs` is the flake ref, `nixpkgs#ponysay` is not

### DIFF
--- a/src/pages/start/2.nix-run.mdx
+++ b/src/pages/start/2.nix-run.mdx
@@ -31,7 +31,7 @@ Future `nix run` invocations should be instantaneous, as Nix doesn't need to bui
 
 What happened here? The [Nix] CLI did a few things:
 
-* It used the `nixpkgs#ponysay` [flake reference][ref] to pull in some Nix code and targeted a specific [flake output][output] (more on this later).
+* It used the `nixpkgs` [flake reference][ref] to pull in some Nix code and targeted the `ponysay` [flake output][output] (more on this later).
 * It built the [`ponysay` package][ponysay] and stored the result in the [Nix store][store].
 * It ran the executable at `bin/ponysay` from the `ponysay` package.
 


### PR DESCRIPTION
Fixes https://github.com/DeterminateSystems/zero-to-nix/issues/158.

---

Rather than trying to work in the "installable" term, I just corrected what "flake reference" was referring to -- `nixpkgs`, not `nixpkgs#ponysay`.