### PR TITLE
Add separate contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to Zero to Nix
+
+We'd love your help with [Zero to Nix][z2n]!
+Here are some ways that you can contribute:
+
+1. You can provide feedback on a specific page by clicking on one of the **Was this page helpful?** options in the bottom left and submitting written text.
+   Keep it respectful, please!
+1. You can propose any change to the site by submitting a [pull request][pr] to the [Zero to Nix repo][repo].
+1. You can click the **Edit this page** button in the lower right, which takes you to GitHub's editor interface for the page you're on.
+1. You can file an [issue] to the [Zero to Nix repo][repo].
+   For your convenience, each page has a **File an issue** button in the lower right that provides values to an issue template indicating which page the issue is being filed for (feel free to change those populated values).
+1. Start a discussion in the repo's [Discussions] section (or participate in an existing discussion).
+
+[discussions]: https://github.com/DeterminateSystems/zero-to-nix/discussions
+[issue]: https://github.com/DeterminateSystems/zero-to-nix/issues
+[pr]: https://github.com/DeterminateSystems/zero-to-nix/
+[repo]: https://github.com/DeterminateSystems/zero-to-nix
+[z2n]: https://zero-to-nix.com

--- a/src/pages/start/1.install.mdx
+++ b/src/pages/start/1.install.mdx
@@ -67,7 +67,7 @@ This should print the version information for Nix.
 You now have Nix installed and ready to go on your system.
 
 <Admonition info title="How to contribute to Zero to Nix" id="contributing" client:load>
-If you're interested in contributing to Zero to Nix, see the [contribution manual][contributing] in the project [repo].
+If you're interested in contributing to Zero to Nix, see the [manual][contributing] in the project [repo] for some suggestions.
 </Admonition>
 
 [apfs]: https://es.wikipedia.org/wiki/Apple_File_System

--- a/src/pages/start/1.install.mdx
+++ b/src/pages/start/1.install.mdx
@@ -66,30 +66,21 @@ This should print the version information for Nix.
 :rocket: **Success**!
 You now have Nix installed and ready to go on your system.
 
-## How to contribute to Zero to Nix \{#contributing}
-
-We'd love to get your help with Zero to Nix!
-There are four main ways to do that:
-
-1. You can provide feedback on a specific page by clicking on one of the **Was this page helpful?** options in the bottom left and submitting written text.
-  Keep it respectful, please!
-1. You can propose any change to the site by submitting a [pull request][pr] to the [Zero to Nix repo][repo].
-1. You can click the **Edit this page** button in the lower right, which takes you to GitHub's editor interface for the page you're on.
-1. You can file an [issue] to the [Zero to Nix repo][repo].
-  For your convenience, each page has a **File an issue** button in the lower right that provides values to an issue template indicating which page the issue is being filed for (feel free to change those populated values).
+<Admonition info title="How to contribute to Zero to Nix" id="contributing" client:load>
+If you're interested in contributing to Zero to Nix, see the [contribution manual][contributing] in the project [repo].
+</Admonition>
 
 [apfs]: https://es.wikipedia.org/wiki/Apple_File_System
 [build]: /start/nix-build-nixpkgs
+[contributing]: https://github.com/DeterminateSystems/zero-to-nix/tree/main/CONTRIBUTING.md
 [detsys]: https://determinate.systems
 [dev]: /start/dev-shell-flake
 [flakes]: /concepts/flakes
-[issue]: https://github.com/DeterminateSystems/zero-to-nix/issues
 [json]: https://json.org
 [multi]: https://nixos.org/manual/nix/stable/installation/multi-user
 [nix]: https://nixos.org
 [nix-installer]: /concepts/nix-installer
 [official]: https://nixos.org/download
-[pr]: https://github.com/DeterminateSystems/zero-to-nix/pulls
 [releases]: https://github.com/DeterminateSystems/nix-installer/releases
 [repo]: https://github.com/DeterminateSystems/zero-to-nix
 [script]: https://raw.githubusercontent.com/DeterminateSystems/nix-installer/main/nix-installer.sh

--- a/vale/Vocab/Docs/accept.txt
+++ b/vale/Vocab/Docs/accept.txt
@@ -102,7 +102,9 @@ shopify
 src
 stdenv
 stdlib
+steamdeck
 sudo
+systemd
 tooltip
 tmux
 tweag


### PR DESCRIPTION
Having a CONTRIBUTING.md is kind of an emerging standard that I'd like to adopt. This PR moves the contributing guideline there, which has the pleasant consequence of removing some text from the install guide.
