### PR TITLE
Fix rustc getting pulled in from user's env

### DIFF
--- a/nix/shell/example.nix
+++ b/nix/shell/example.nix
@@ -56,7 +56,7 @@
   };
 
   rust = pkgs.mkShell {
-    packages = with pkgs; [ cargo ];
+    packages = with pkgs; [ cargo rustc ];
 
     shellHook = ''
       echo "Welcome to a Nix development environment for Rust!"


### PR DESCRIPTION
Verified this fixes #200

```shell
zero-to-nix on  bugfix/rust-example via  v16.19.0
❯ cd nix/shell

zero-to-nix/nix/shell on  bugfix/rust-example
❯ rustc --version
rustc 1.69.0-nightly (001a77fac 2023-01-30)

zero-to-nix/nix/shell on  bugfix/rust-example
❯ cat example.nix | rg rust -B5
    shellHook = ''
      echo "Welcome to a Nix development environment for Go!"
    '';
  };

  rust = pkgs.mkShell {
    packages = with pkgs; [ cargo rustc ];

zero-to-nix/nix/shell on  bugfix/rust-example
❯ nix develop ".#rust"
path '/home/will/code/zero-to-nix/nix/shell' does not contain a 'flake.nix', searching up
Welcome to a Nix development environment for Rust!

[will@betelgeuse:~/code/zero-to-nix/nix/shell]$ rustc --version
rustc 1.64.0
```