### PR TITLE
Add libiconv dependency for macOS in Rust dev env

### DIFF
--- a/nix/templates/dev/rust/flake.nix
+++ b/nix/templates/dev/rust/flake.nix
@@ -34,11 +34,11 @@
       devShells = forAllSystems ({ pkgs }: {
         default = pkgs.mkShell {
           # The Nix packages provided in the environment
-          packages = with pkgs; [
+          packages = (with pkgs; [
             # The package provided by our custom overlay. Includes cargo, Clippy, cargo-fmt,
             # rustdoc, rustfmt, and other tools.
             rustToolchain
-          ];
+          ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ libiconv ]);
         };
       });
     };


### PR DESCRIPTION
Fixes #203
