### PR TITLE
Add funny joke to shell hook example

### DIFF
--- a/nix/shell/example.nix
+++ b/nix/shell/example.nix
@@ -1,19 +1,20 @@
 { pkgs }:
 
+let
+  joke = { FUNNY_JOKE = "What kind of phone does a turtle use? A shell phone!"; };
+in
 {
-  example = pkgs.mkShell {
+  example = pkgs.mkShell (joke // {
     packages = with pkgs; [ curl jq git ];
+  });
 
-    FUNNY_JOKE = "What kind of phone does a turtle use? A shell phone!";
-  };
-
-  hook = pkgs.mkShell {
+  hook = pkgs.mkShell (joke // {
     shellHook = ''
       echo "Congrats! You just triggered a shell hook for a Nix development environment."
       echo "Run \"exit\" to exit this environment."
       echo "Then run \"nix develop github:DeterminateSystems/zero-to-nix#hook\" again to re-trigger this hook."
     '';
-  };
+  });
 
   cpp = pkgs.mkShell {
     packages = with pkgs; [ gcc cmake ];


### PR DESCRIPTION
In Guide 4 I was ordered to:

> Run this to see an example shell hook:
> ```nix develop "github:DeterminateSystems/zero-to-nix#hook"```
> Nix development environments support environment variables as well. Run echo $FUNNY_JOKE to access a (hilarious) value that's available only in the Nix environment.

The problem is that only `#example` shell sets this variable and it doesn't work in `#hook` shell.
This PR makes above example work.