### PR TITLE
Add audience clarification in quick start

### DIFF
--- a/src/pages/start/1.install.mdx
+++ b/src/pages/start/1.install.mdx
@@ -7,6 +7,13 @@ summary: [
 ]
 ---
 
+<Admonition success open title="The target audience for the quick start" id="quick-start-audience" client:load>
+We wrote this [Zero to Nix][z2n] quick start with one specific audience in mind: people who have heard about [Nix] but don't yet know much about it and aren't quite sure where to start with the learning process.
+It's intended less as a how-to guide for using Nix in your everyday workflows and more to provide a glimpse into Nix's feature set and to provide some of those "a-ha!" moments that make you feel empowered to go further.
+
+If you're already fairly familiar with Nix and are looking for specific guidance on using it in your day job, you may still get some value out of the quick start but you may be better served with more practical, guide-driven resources like [nix.dev].
+</Admonition>
+
 **Welcome**!
 It's great to see that you're interested in [Nix].
 In this [quick start][start], we'll get Nix installed on your system and provide you with a small taste of Nix's feature set by accomplishing some practical things, such as [creating a development environment][dev] and [building a package][build] using Nix.
@@ -76,6 +83,7 @@ If you're interested in contributing to Zero to Nix, see the [manual][contributi
 [multi]: https://nixos.org/manual/nix/stable/installation/multi-user
 [nix]: https://nixos.org
 [nix-installer]: /concepts/nix-installer
+[nix.dev]: https://nix.dev
 [official]: https://nixos.org/download
 [releases]: https://github.com/DeterminateSystems/nix-installer/releases
 [repo]: https://github.com/DeterminateSystems/zero-to-nix
@@ -86,3 +94,4 @@ If you're interested in contributing to Zero to Nix, see the [manual][contributi
 [store]: /concepts/nix-store
 [systemd]: https://systemd.io
 [uninstall]: /start/uninstall
+[z2n]: /


### PR DESCRIPTION
This should help to establish proper expectations of the quick start for would-be readers, some of whom have criticized the quick start for being a bit thin. Those folks aren't *wrong*, but they may be better served by being alerted that they aren't the target audience per se.
