### PR TITLE
Fix system architecture comments in templates

### DIFF
--- a/nix/templates/dev/cpp/flake.nix
+++ b/nix/templates/dev/cpp/flake.nix
@@ -11,10 +11,10 @@
     let
       # Systems supported
       allSystems = [
-        "x86_64-linux" # 64-bit Intel/ARM Linux
-        "aarch64-linux" # 64-bit AMD Linux
-        "x86_64-darwin" # 64-bit Intel/ARM macOS
-        "aarch64-darwin" # 64-bit Apple Silicon
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "x86_64-darwin" # 64-bit Intel macOS
+        "aarch64-darwin" # 64-bit ARM macOS
       ];
 
       # Helper to provide system-specific attributes

--- a/nix/templates/dev/go/flake.nix
+++ b/nix/templates/dev/go/flake.nix
@@ -11,10 +11,10 @@
     let
       # Systems supported
       allSystems = [
-        "x86_64-linux" # 64-bit Intel/ARM Linux
-        "aarch64-linux" # 64-bit AMD Linux
-        "x86_64-darwin" # 64-bit Intel/ARM macOS
-        "aarch64-darwin" # 64-bit Apple Silicon
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "x86_64-darwin" # 64-bit Intel macOS
+        "aarch64-darwin" # 64-bit ARM macOS
       ];
 
       # Helper to provide system-specific attributes

--- a/nix/templates/dev/haskell/flake.nix
+++ b/nix/templates/dev/haskell/flake.nix
@@ -11,10 +11,10 @@
     let
       # Systems supported
       allSystems = [
-        "x86_64-linux" # 64-bit Intel/ARM Linux
-        "aarch64-linux" # 64-bit AMD Linux
-        "x86_64-darwin" # 64-bit Intel/ARM macOS
-        "aarch64-darwin" # 64-bit Apple Silicon
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "x86_64-darwin" # 64-bit Intel macOS
+        "aarch64-darwin" # 64-bit ARM macOS
       ];
 
       # Helper to provide system-specific attributes

--- a/nix/templates/dev/javascript/flake.nix
+++ b/nix/templates/dev/javascript/flake.nix
@@ -11,10 +11,10 @@
     let
       # Systems supported
       allSystems = [
-        "x86_64-linux" # 64-bit Intel/ARM Linux
-        "aarch64-linux" # 64-bit AMD Linux
-        "x86_64-darwin" # 64-bit Intel/ARM macOS
-        "aarch64-darwin" # 64-bit Apple Silicon
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "x86_64-darwin" # 64-bit Intel macOS
+        "aarch64-darwin" # 64-bit ARM macOS
       ];
 
       # Helper to provide system-specific attributes

--- a/nix/templates/dev/python/flake.nix
+++ b/nix/templates/dev/python/flake.nix
@@ -11,10 +11,10 @@
     let
       # Systems supported
       allSystems = [
-        "x86_64-linux" # 64-bit Intel/ARM Linux
-        "aarch64-linux" # 64-bit AMD Linux
-        "x86_64-darwin" # 64-bit Intel/ARM macOS
-        "aarch64-darwin" # 64-bit Apple Silicon
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "x86_64-darwin" # 64-bit Intel macOS
+        "aarch64-darwin" # 64-bit ARM macOS
       ];
 
       # Helper to provide system-specific attributes


### PR DESCRIPTION
This is a tiny nit, but aarch64 is ARM and isn't made by AMD and ARM doesn't make anything that runs x86_64 that I know of. I had to Google that when I init'd with this template, so I assumed others would appreciate not having to look it up.

Thanks for a fantastic set of docs!