### PR TITLE
Drop the canonical tag

### DIFF
--- a/src/layouts/base.vue
+++ b/src/layouts/base.vue
@@ -32,7 +32,6 @@ const canonical = new URL(url, href).toString();
 
 useHead({
   link: [
-    { rel: "canonical", href: canonical },
     { rel: "shortcut icon", type: "image/png", href: "/favicon.png" },
   ],
   meta: tags && [{ name: "keywords", content: tags!.join(",") }],


### PR DESCRIPTION
It seems every page gets its the root index as its canonical, which is causing some indexing problems. We should get the canonical tag back, but I think this is a good short term solution.