### PR TITLE
Fix link destination for provenance concept.

### DIFF
--- a/src/pages/concepts/sandboxing.mdx
+++ b/src/pages/concepts/sandboxing.mdx
@@ -14,3 +14,4 @@ Nix builds are sandboxed for a variety of reasons:
 1. To maintain strict [provenance].
 
 [reproducibility]: /concepts/reproducibility
+[provenance]: /concepts/provenance


### PR DESCRIPTION
Link destination was missing. 

Full disclosure - I'm not 100% positive I did this right, but it looks pretty simple; I just copied the syntax from other link defs in the file / related files, and it appears to be the same. Hopefully it works!