### PR TITLE
fix blog link

### DIFF
--- a/src/pages/start/2.nix-run.mdx
+++ b/src/pages/start/2.nix-run.mdx
@@ -51,7 +51,7 @@ For more on `nix run`, see [Using Nix to run software with no installation steps
 You've just run a program using the Nix CLI and learned a little bit about some core Nix concepts.
 You're now ready to explore Nix development environments.
 
-[blog]: https://determinate.systems/posts
+[blog]: https://determinate.systems/#blog
 [cache]: /concepts/caching
 [derivations]: /concepts/nix-language#derivations
 [ffmpeg]: https://ffmpeg.org

--- a/src/pages/start/3.nix-develop.mdx
+++ b/src/pages/start/3.nix-develop.mdx
@@ -368,7 +368,7 @@ Probably not what you expected! What happened here? A few things:
   [Nix store][store] under `/nix/store`.
 
 [bash]: https://gnu.org/software/bash
-[blog]: https://determinate.systems/posts
+[blog]: https://determinate.systems/#blog
 [cargo]: https://doc.rust-lang.org/stable/cargo
 [cmake]: https://cmake.org
 [curl]: https://curl.se


### PR DESCRIPTION
Some links to blog (https://determinate.systems/posts) is a already a 404 page right now.

This PR corrects to these links.