### PR TITLE
Fix broken nix.dev link in 7.learn-more.mdx

### DIFF
--- a/src/pages/start/7.learn-more.mdx
+++ b/src/pages/start/7.learn-more.mdx
@@ -34,7 +34,7 @@ Another powerful Nix feature is that you can use it to build [OCI]-compliant con
   },
   {
     title: "Building and running Docker images",
-    href: "https://nix.dev/tutorials/building-and-running-docker-images",
+    href: "https://nix.dev/tutorials/nixos/build-and-deploy/building-and-running-docker-images",
     source: {
       title: "nix.dev",
       href: "https://nix.dev"


### PR DESCRIPTION
The current link (https://nix.dev/tutorials/building-and-running-docker-images) is now broken. The correct link is: https://nix.dev/tutorials/nixos/build-and-deploy/building-and-running-docker-images