### PR TITLE
Fix nix.dev url for Building and running Docker images

### DIFF
--- a/src/pages/start/7.learn-more.mdx
+++ b/src/pages/start/7.learn-more.mdx
@@ -34,7 +34,7 @@ Another powerful Nix feature is that you can use it to build [OCI]-compliant con
   },
   {
     title: "Building and running Docker images",
-    href: "https://nix.dev/tutorials/nixos/build-and-deploy/building-and-running-docker-images",
+    href: "https://nix.dev/tutorials/nixos/building-and-running-docker-images#",
     source: {
       title: "nix.dev",
       href: "https://nix.dev"

--- a/src/pages/start/7.learn-more.mdx
+++ b/src/pages/start/7.learn-more.mdx
@@ -34,7 +34,7 @@ Another powerful Nix feature is that you can use it to build [OCI]-compliant con
   },
   {
     title: "Building and running Docker images",
-    href: "https://nix.dev/tutorials/nixos/building-and-running-docker-images#",
+    href: "https://nix.dev/tutorials/nixos/building-and-running-docker-images",
     source: {
       title: "nix.dev",
       href: "https://nix.dev"


### PR DESCRIPTION
The URL for "Building and running Docker images" results in a 404 at nix.dev. This change points to, what I believe to be, the current version of that document. Especially if the [current google cache](https://webcache.googleusercontent.com/search?q=cache%3A9hulwhM6SWEJ%3Ahttps%3A%2F%2Fnix.dev%2Ftutorials%2Fnixos%2Fbuild-and-deploy%2Fbuilding-and-running-docker-images&cd=9&hl=en&ct=clnk&gl=us) for that URL is correct.

