### PR TITLE
Remove "no SELinux" specifier from Linux in supported platforms list

### DIFF
--- a/src/pages/start/1.install.mdx
+++ b/src/pages/start/1.install.mdx
@@ -23,7 +23,7 @@ The installer supports these platforms:
 
 Platform | Multi user? | `root` only
 :--------|:------------|:-----------
-Linux on 64-bit ARM and 64-bit AMD/Intel (no [SELinux]) | ✅ (via [systemd]) | ✅
+Linux on 64-bit ARM and 64-bit AMD/Intel | ✅ (via [systemd]) | ✅
 macOS on 64-bit ARM and 64-bit AMD/Intel | ✅ |
 [Valve Steam Deck][steamdeck] (SteamOS) | ✅ |
 [Windows Subsystem for Linux][wsl] (WSL) on 64-bit ARM and 64-bit AMD/Intel | ✅ (via [systemd]) | ✅
@@ -93,7 +93,6 @@ If you're interested in contributing to Zero to Nix, see the [manual][contributi
 [releases]: https://github.com/DeterminateSystems/nix-installer/releases
 [repo]: https://github.com/DeterminateSystems/zero-to-nix
 [script]: https://raw.githubusercontent.com/DeterminateSystems/nix-installer/main/nix-installer.sh
-[selinux]: https://www.redhat.com/en/topics/linux/what-is-selinux
 [start]: /start
 [steamdeck]: https://steamdeck.com
 [store]: /concepts/nix-store


### PR DESCRIPTION
As of [`v0.9.0`][release], the Determinate Nix Installer [supports SELinux-enabled systems][pr] (thanks, @Hoverbear!). The quick start install page still mentions SELinux systems as being unsupported- let's update the install page to reflect this change.

Resolves #267

[release]: https://github.com/DeterminateSystems/nix-installer/releases/tag/v0.9.0
[pr]: https://github.com/DeterminateSystems/nix-installer/pull/465