### PR TITLE
Update link to buildgomodule in derivations.mdx

### DIFF
--- a/src/pages/concepts/derivations.mdx
+++ b/src/pages/concepts/derivations.mdx
@@ -124,7 +124,7 @@ Arguments:
 Outside of `stdenv.mkDerivation`, there are many custom derivation wrappers for specific languages, frameworks, and more (and many of those actually wrap `stdenv.mkDerivation`).
 Some examples:
 
-- [`buildGoModule`][go] for [Go]
+- [`buildGoModule`][buildgomodule] for [Go]
 - [`buildRustPackage`][buildrustpackage] for [Rust]
 - [`buildPythonApplication`][buildpythonapplication] for [Python]
 


### PR DESCRIPTION
The derivation wrappers for rust and python point to nixos docs and it looks like the go one was supposed to as well, but currently it points to https://go.dev