### PR TITLE
Fix: link to `bat` package

### DIFF
--- a/src/pages/start/4.nix-build.mdx
+++ b/src/pages/start/4.nix-build.mdx
@@ -373,7 +373,7 @@ We won't delve too much deeper into [derivations][derivation] and creating your 
 [kubectl]: https://github.com/kubernetes/kubectl
 [nix]: /concepts/nix
 [nixpkgs]: /concepts/nixpkgs
-[nixpkgs-bat]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/bat/default.nix
+[nixpkgs-bat]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ba/bat/package.nix
 [nixpkgs-repo]: https://github.com/NixOS/nixpkgs
 [npm]: https://npmjs.org
 [npx]: https://docs.npmjs.com/cli/v8/commands/npx


### PR DESCRIPTION
`bat` package has been moved recently (see [ec5b438](https://github.com/NixOS/nixpkgs/commit/ec5b43883a118aec791a273d739048eaf8b88a2a))