### PR TITLE
Add FUNNY_JOKE to first two examples.

### DIFF
--- a/nix/shell/example.nix
+++ b/nix/shell/example.nix
@@ -15,6 +15,8 @@
       echo "Run \"exit\" to exit this environment."
       echo "Then run \"nix develop github:DeterminateSystems/zero-to-nix#hook\" again to re-trigger this hook."
     '';
+
+    FUNNY_JOKE = "What kind of phone does a turtle use? A shell phone!";
   };
 
   cpp = pkgs.mkShell {


### PR DESCRIPTION
Minor nit, but in zero-to-nix under the nix-develop section the reference to the environment variable 'FUNNY_JOKE' is under the the "hook" example, not the "zero-to-nix" example. So the user (also known as myself) could be in either or when entering "echo $FUNNY_JOKE".