### PR TITLE
Fix go version

### DIFF
--- a/src/pages/start/3.nix-develop.mdx
+++ b/src/pages/start/3.nix-develop.mdx
@@ -170,7 +170,7 @@ Now check the Go version:
 go version
 ```
 
-You should get 1.19.
+You should get 1.19.12
 </SpecificLanguage>
 <SpecificLanguage client:load lang="Rust">
 First, let's see the Nix store path for [cargo]:

--- a/src/pages/start/3.nix-develop.mdx
+++ b/src/pages/start/3.nix-develop.mdx
@@ -170,7 +170,7 @@ Now check the Go version:
 go version
 ```
 
-You should get 1.19.3.
+You should get 1.19.
 </SpecificLanguage>
 <SpecificLanguage client:load lang="Rust">
 First, let's see the Nix store path for [cargo]:


### PR DESCRIPTION
`go version` is returning 1.19.12

Do you think is more clear to put 1.19.x?