### PR TITLE
Update with correct SHA for go pkg

### DIFF
--- a/nix/templates/pkg/go/flake.nix
+++ b/nix/templates/pkg/go/flake.nix
@@ -25,7 +25,7 @@
         default = pkgs.buildGoModule {
           name = "zero-to-nix-go";
           src = ./.;
-          vendorSha256 = "sha256-pYnN8rxXNNLRegvJySwAyMUPBmnhSiDSHfMQpjB9Qjs=";
+          vendorSha256 = "sha256-Cy1/QqbO2MyYgqJZKxrt1FZzLSgXbhSK3ceFPUlFujw=";
         };
       });
     };


### PR DESCRIPTION
Running the zero-to-nix tutorial I got the following error message:

```
nix-go-pkg $ nix build
error: hash mismatch in fixed-output derivation '/nix/store/5j60chscsydnha39hzszg4yv4dzbxf4n-zero-to-nix-go-go-modules.drv':
         specified: sha256-pYnN8rxXNNLRegvJySwAyMUPBmnhSiDSHfMQpjB9Qjs=
            got:    sha256-Cy1/QqbO2MyYgqJZKxrt1FZzLSgXbhSK3ceFPUlFujw=
error: 1 dependencies of derivation '/nix/store/ii6iyv0gkwbfrczwymj0hfk3sdfbliji-zero-to-nix-go.drv' failed to build
```

I'm completely new to Nix, but I'm assuming the SHA needs to be updated because something changed somewhere