### PR TITLE
fix: hash mismatch for npmDepsHash

### DIFF
--- a/nix/templates/pkg/javascript/flake.nix
+++ b/nix/templates/pkg/javascript/flake.nix
@@ -31,7 +31,7 @@
 
           src = ./.;
 
-          npmDepsHash = "sha256-8Bj7nPZBAU+SnVTeKeArcjYnfZV4z/4I7fX+l0V+v04=";
+          npmDepsHash = "sha256-A/q4C8Ox1InaJ/320+pU9uBUv6zqTKlzzOmJUvzBOnI=";
 
           npmBuild = "npm run build";
 

--- a/src/pages/start/4.nix-build.mdx
+++ b/src/pages/start/4.nix-build.mdx
@@ -233,7 +233,7 @@ Here's the package definition that builds our JavaScript package:
 
     # The code sources for the package
     src = ./.;
-    npmDepsHash = "sha256-8Bj7nPZBAU+SnVTeKeArcjYnfZV4z/4I7fX+l0V+v04=";
+    npmDepsHash = "sha256-A/q4C8Ox1InaJ/320+pU9uBUv6zqTKlzzOmJUvzBOnI=";
 
     # How the output of the build phase
     installPhase = ''


### PR DESCRIPTION
Running `nix build` after nix flake `init --template "github:DeterminateSystems/zero-to-nix#javascript-pkg"` gives a hash mismatch error. This pull request addresses that and adds the correct hash making the environment reproducible.