### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/src/pages/concepts/channels.mdx
+++ b/src/pages/concepts/channels.mdx
@@ -7,7 +7,7 @@ related: ["flakes", "pinning"]
 externalSources: [
   {
     title: "Nix channels",
-    href: "https://nixos.wiki/wiki/Nix_channels",
+    href: "https://wiki.nixos.org/wiki/Nix_channels",
     source: {
       title: "The NixOS wiki",
       href: "https://wiki.nixos.org"


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️