### PR TITLE
Side notes for users not seeing matching output

### DIFF
--- a/src/pages/start/2.nix-run.mdx
+++ b/src/pages/start/2.nix-run.mdx
@@ -27,6 +27,13 @@ This is in contrast to most [package managers][pkg], which install things more q
 Future `nix run` invocations should be instantaneous, as Nix doesn't need to build the package again.
 </Admonition>
 
+<Admonition warning title="If you installed nix on your own" id="nix-run-loading" client:load>
+If you installed Nix by means other than the [Determinate Nix Installer][nix-installer], you'll probably need to manually enable the nix command and flakes 
+(if you're seeing an error about experimental features, this it you). you can find out how to activate those features on their respective Nix wiki 
+pages: see [nix command](https://nixos.wiki/wiki/Nix_command) and [flakes](https://nixos.wiki/wiki/Flakes).
+</Admonition>
+
+
 ## Explanation
 
 What happened here? The [Nix] CLI did a few things:

--- a/src/pages/start/3.nix-develop.mdx
+++ b/src/pages/start/3.nix-develop.mdx
@@ -42,6 +42,12 @@ type curl
 type git
 ```
 
+If your shell prompt didn't change, you should still be able to tell something happened by checking the `FUNNY_JOKE` variable added by the 
+development environment we just activated:
+```shell
+echo $FUNNY_JOKE
+```
+
 For curl, for example, you should see a strange path like this (the hash part should be different on your machine):
 
 <NixStorePath pkg="curl-8.1.1-bin" bin="curl" />


### PR DESCRIPTION
I'm trying to work through the examples having used the official installer, and there are some minor differences between what's in the guide and what you get with an official install.  I do not think the authors/maintainers should have to do extra work to support people who aren't following directions, but I also think many would-be readers will be working off an official install (e.g. someone trying out nixos in a VM), so as long as the differences can be patched with small footnotes it probably doesn't hurt.

The first one is that you need to activate flakes/nix command, the second is that you don't get a visual cue when running the nix develop example in entry 3 (this closes #315 which had the same issue).

