### PR TITLE
Update checksums in package templates

### DIFF
--- a/nix/templates/pkg/go/flake.nix
+++ b/nix/templates/pkg/go/flake.nix
@@ -25,7 +25,7 @@
         default = pkgs.buildGoModule {
           name = "zero-to-nix-go";
           src = ./.;
-          vendorSha256 = "sha256-pYnN8rxXNNLRegvJySwAyMUPBmnhSiDSHfMQpjB9Qjs=";
+          vendorSha256 = "sha256-Cy1/QqbO2MyYgqJZKxrt1FZzLSgXbhSK3ceFPUlFujw=";
         };
       });
     };

--- a/nix/templates/pkg/javascript/flake.nix
+++ b/nix/templates/pkg/javascript/flake.nix
@@ -31,7 +31,7 @@
 
           src = ./.;
 
-          npmDepsHash = "sha256-8Bj7nPZBAU+SnVTeKeArcjYnfZV4z/4I7fX+l0V+v04=";
+          npmDepsHash = "sha256-A/q4C8Ox1InaJ/320+pU9uBUv6zqTKlzzOmJUvzBOnI=";
 
           npmBuild = "npm run build";
 


### PR DESCRIPTION
The package templates for Go and Javascript, which are both referenced on the 'Build a package using Nix' page, have become outdated due to automated dependency updates (these should probably be disabled for templates?).

Users who try to execute the examples receive an error when trying a `nix build` on these examples:
```console
$ nix build
error: hash mismatch in fixed-output derivation '/nix/store/s5yjx...-zero-to-nix-go-go-modules.drv':
         specified: sha256-pYnN8rxXNNLRegvJySwAyMUPBmnhSiDSHfMQpjB9Qjs=
            got:    sha256-Cy1/QqbO2MyYgqJZKxrt1FZzLSgXbhSK3ceFPUlFujw=
error: 1 dependencies of derivation '/nix/store/d49n...-zero-to-nix-go.drv' failed to build
```

Supersedes / Closes #341 and closes #343, which have both been apparently overlooked.
Fixes #348 and fixes #331