### PR TITLE
correct path to go flake template

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -159,7 +159,7 @@
         };
 
         go-dev = {
-          path = ./nix/templates/dev/go;
+          path = ./nix/templates/dev/golang;
           description = "Go dev environment template for Zero to Nix";
         };
 


### PR DESCRIPTION
# Summary

I was following the zero to nix website and got to section 3 "From a local flake" https://zero-to-nix.com/start/nix-develop#flake. I selected go and used the command. 
I believe the path to the go template referenced in the root flake.nix was incorrect. I cloned it, and tried to run

```zsh
nix flake init -t "../github.com/hampgoodwin/zero-to-nix/flake.nix#go-dev"
```

and got 

```
path '/home/hamp/github.com/hampgoodwin/zero-to-nix/flake.nix' does not contain a 'flake.nix', searching up
warning: Git tree '/home/hamp/github.com/hampgoodwin/zero-to-nix' is dirty
error: opening directory '/nix/store/40a8q71915rhvpy4crc6ifvzz8m5xlm0-source/nix/templates/dev/go': No such file or directory
```

With the change herein and running the same I was able to get a templated flake.
