### PR TITLE
Use OpenTofu in dev shell instead of Terraform

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726447378,
-        "narHash": "sha256-2yV8nmYE1p9lfmLHhOCbYwQC/W8WYfGQABoGzJOb1JQ=",
-        "rev": "086b448a5d54fd117f4dc2dee55c9f0ff461bdc1",
-        "revCount": 635167,
+        "lastModified": 1729973466,
+        "narHash": "sha256-knnVBGfTCZlQgxY1SgH0vn2OyehH9ykfF8geZgS95bk=",
+        "rev": "cd3e8833d70618c4eea8df06f95b364b016d4950",
+        "revCount": 636163,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.635167%2Brev-086b448a5d54fd117f4dc2dee55c9f0ff461bdc1/0192005b-cf99-7543-8e3a-deb3339dad33/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.636163%2Brev-cd3e8833d70618c4eea8df06f95b364b016d4950/0192cd43-85cd-7ff3-b9be-a3f7995e917d/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/shell/example.nix
+++ b/nix/shell/example.nix
@@ -74,7 +74,7 @@
   };
 
   multi = pkgs.mkShell {
-    packages = with pkgs; [ python39 kubectl openssl terraform ];
+    packages = with pkgs; [ python39 kubectl openssl opentofu ];
 
     shellHook = ''
       echo "Welcome to a very mixed Nix development environment!"

--- a/src/briefs/nix-installer-differences.mdx
+++ b/src/briefs/nix-installer-differences.mdx
@@ -6,7 +6,7 @@ The Determinate Nix Installer, from [Determinate Systems][ds], differs from the 
 
 1. It installs Nix with [flake support][flakes] and the [unified CLI][cli] feature already enabled rather than requiring users to enable those features.
 1. It stores a *receipt* for the install process at `/nix/receipt.json`. This receipt enables the Determinate Nix Installer to seamlessly uninstall Nix, whereas the official Nix installation script provides no offboarding path of this kind.
-1. Much like [Terraform], the Determinate Nix Installer enables you to [plan][tf-plan] your installation using the [`plan`][dni-plan] command to see how Nix Installer will change your system. We see this as an improvement over the official Nix installation script, which prompts you to approve changes but doesn't present *all* changes.
+1. Much like [Terraform]/[OpenTofu], the Determinate Nix Installer enables you to [plan][tf-plan] your installation using the [`plan`][dni-plan] command to see how the installer will change your system. We see this as an improvement over the official Nix installation script, which prompts you to approve changes but doesn't present *all* changes.
 1. The Determinate Nix Installer is written in [Rust] rather than a shell scripting language (the official installer is written in [Bash]). This has two key benefits:
     1. It makes the Determinate Nix Installer more portable across platforms.
     1. It enables the Determinate Nix Installer to parallelize CPU-intensive tasks, which can't be achieved in a language like Bash.
@@ -18,6 +18,7 @@ The Determinate Nix Installer, from [Determinate Systems][ds], differs from the 
 [ds]: https://determinate.systems
 [flakes]: /concepts/flakes
 [official]: https://nixos.org/download
+[opentofu]: https://opentofu.org
 [rust]: https://rust-lang.org
 [terraform]: https://terraform.io
 [tf-plan]: https://developer.hashicorp.com/terraform/cli/commands/plan

--- a/src/pages/start/3.nix-develop.mdx
+++ b/src/pages/start/3.nix-develop.mdx
@@ -219,7 +219,7 @@ This Nix environment has several tools available:
 
 * [Python]
 * [kubectl]
-* [Terraform]
+* [OpenTofu]
 * [OpenSSL]
 
 As in the previous examples, you can run commands like `type python` and `type kubectl` to see that these tools are all discoverable in the [Nix store][store] and not somewhere like `/usr/bin`.
@@ -392,6 +392,7 @@ Probably not what you expected! What happened here? A few things:
 [node.js]: https://nodejs.org
 [npm]: https://npmjs.org
 [openssl]: https://openssl.org
+[opentofu]: https://opentofu.org
 [output]: /concepts/flakes#outputs
 [packages]: /concepts/packages
 [path]: https://en.wikipedia.org/wiki/PATH_(variable)
@@ -404,4 +405,4 @@ Probably not what you expected! What happened here? A few things:
 [sbt]: https://scala-sbt.org
 [store]: /concepts/nix-store
 [templates]: /concepts/flakes#templates
-[terraform]: https://terraform.io
+

--- a/styles/config/vocabularies/Docs/accept.txt
+++ b/styles/config/vocabularies/Docs/accept.txt
@@ -88,6 +88,7 @@ offboarding
 onboarding
 openssh
 openssl
+opentofu
 pandoc
 pkgs
 plaintext


### PR DESCRIPTION
Terraform is no longer considered free in Nixpkgs. We _could_ set `allowUnfree = true` in Nixpkgs to get around this but generally easier to just switch to a free package.