### PR TITLE
Fix AlpineJS warning

### DIFF
--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -15,7 +15,7 @@ type Props = {
 const { breadcrumb, order, total } = Astro.props;
 ---
 
-<div x-cloak x-show="breadcrumb" class="flex items-center justify-between">
+<div x-cloak class="flex items-center justify-between">
   <div
     class="flex items-center space-x-2 text-sm md:space-x-2.5 md:text-base lg:space-x-3 lg:text-lg"
   >


### PR DESCRIPTION
AlpineJS is currently throwing this warning on some pages:

```
Uncaught ReferenceError: breadcrumb is not defined
    anonymous https://zero-to-nix.com/_astro/page.CwLfWgBQ.js line 5 > AsyncFunction:3
    Ar https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    br https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:1
    <anonymous> https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    n https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    wi https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    D https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:1
    fr https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:1
    <anonymous> https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    n https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    r https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    Mr https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    C https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    Pr https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    Pr https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
    <anonymous> https://zero-to-nix.com/_astro/page.CwLfWgBQ.js:5
```

Removing the unused `x-show` directive here fixes that issue.