### PR TITLE
Reference official wiki's version of page

### DIFF
--- a/src/content/concepts/channels.mdx
+++ b/src/content/concepts/channels.mdx
@@ -6,8 +6,8 @@ snippet: |
 related: ["flakes", "pinning"]
 externalSources: [
   {
-    title: "Nix channels",
-    href: "https://nixos.wiki/wiki/Nix_channels",
+    title: "Channel branches",
+    href: "https://wiki.nixos.org/wiki/Channel_branches",
     source: {
       title: "The NixOS wiki",
       href: "https://wiki.nixos.org"


### PR DESCRIPTION
Page was [renamed last year](https://wiki.nixos.org/w/index.php?title=Channel_branches&diff=11235&oldid=11234), which probably explains why the unofficial wiki was used here instead, since they did not rename their version.