### PR TITLE
Obviate needing the explicit javascript hash

### DIFF
--- a/nix/templates/pkg/javascript/flake.nix
+++ b/nix/templates/pkg/javascript/flake.nix
@@ -31,9 +31,11 @@
 
           src = self;
 
-          npmDepsHash = "sha256-wfuvrCG5H4/Igqt6pyrKPHBblgGdkGNOHWu7i6DTWEE=";
+          npmDeps = pkgs.importNpmLock {
+            npmRoot = ./.;
+          };
 
-          npmBuild = "npm run build";
+          npmConfigHook = pkgs.importNpmLock.npmConfigHook;
 
           installPhase = ''
             mkdir $out

--- a/src/content/start/4.nix-build.mdx
+++ b/src/content/start/4.nix-build.mdx
@@ -283,14 +283,16 @@ Here's the package definition that builds our JavaScript package:
       name = "zero-to-nix-javascript";
 
       buildInputs = with pkgs; [
-        nodejs_18
+        nodejs_latest
       ];
 
       src = self;
 
-      npmDepsHash = "sha256-A/q4C8Ox1InaJ/320+pU9uBUv6zqTKlzzOmJUvzBOnI=";
+      npmDeps = pkgs.importNpmLock {
+        npmRoot = ./.;
+      };
 
-      npmBuild = "npm run build";
+      npmConfigHook = pkgs.importNpmLock.npmConfigHook;
 
       installPhase = ''
         mkdir $out


### PR DESCRIPTION
Using the fancy function for loading the javascript package.json means you don't need to use a hard-coded hash.