### PR TITLE
Fix Python dev shell

### DIFF
--- a/nix/shell/example.nix
+++ b/nix/shell/example.nix
@@ -74,7 +74,7 @@
   };
 
   multi = pkgs.mkShell {
-    packages = with pkgs; [ python39 kubectl openssl opentofu ];
+    packages = with pkgs; [ python313 kubectl openssl opentofu ];
 
     shellHook = ''
       echo "Welcome to a very mixed Nix development environment!"

--- a/nix/shell/example.nix
+++ b/nix/shell/example.nix
@@ -42,7 +42,7 @@
   };
 
   python = pkgs.mkShell {
-    packages = with pkgs; [ python39 ];
+    packages = with pkgs; [ python313 ];
 
     shellHook = ''
       echo "Welcome to a Nix development environment for Python!"


### PR DESCRIPTION
This `python39` package no longer exists, which is breaking the Python example dev shell.
Updating to a more modern Python fixes this.

Fixes #432
