### PR TITLE
Simplify installation info table

### DIFF
--- a/src/components/mdx/Languages.astro
+++ b/src/components/mdx/Languages.astro
@@ -17,7 +17,6 @@ const { languages } = site;
         <button
           @click={`language = "${lang}"`}
           class="rounded-lg border-1.5 px-1.5 py-1 text-sm font-semibold tracking-tight focus:outline-none md:px-2 md:py-0.5 md:text-base lg:px-3 lg:py-1.5 lg:text-lg"
-          class:list={[]}
 
           :class=`{ "border-primary bg-pale dark:bg-darker-gray": language == "${lang}", "border-pale hover:text-primary dark:border-dark": language !== "${lang}" }`
         >

--- a/src/content/start/1.install.mdx
+++ b/src/content/start/1.install.mdx
@@ -22,14 +22,12 @@ In this [quick start][start], we'll get Nix installed on your system and provide
 We recommend installing Nix using the [Determinate Nix installer][nix-installer], a tool from [Determinate Systems][detsys] that tailors the installation process to your system.
 The installer supports these platforms:
 
-| Platform                                                                    | Multi user?        | `root` only? |
-| :-------------------------------------------------------------------------- | :----------------- | :----------- |
-| Linux on 64-bit ARM and 64-bit AMD/Intel                                    | ✅ (via [systemd]) | ✅           |
-| macOS on 64-bit ARM and 64-bit AMD/Intel                                    | ✅                 |              |
-| [Valve Steam Deck][steamdeck] (SteamOS)                                     | ✅                 |              |
-| [Windows Subsystem for Linux][wsl] (WSL) on 64-bit ARM and 64-bit AMD/Intel | ✅ (via [systemd]) | ✅           |
-| [Podman] Linux containers                                                   | ✅ (via [systemd]) | ✅           |
-| [Docker] containers                                                         |                    | ✅           |
+- macOS on 64-bit ARM and 64-bit AMD/Intel
+- Linux on 64-bit ARM and 64-bit AMD/Intel
+- [Windows Subsystem for Linux][wsl] (WSL) on 64-bit ARM and 64-bit AMD/Intel
+- [Podman] Linux containers
+- Docker] containers
+- [Valve Steam Deck][steamdeck] (SteamOS)
 
 ## Run the installer \{#run}
 


### PR DESCRIPTION
The table is needlessly intimdating as-is. A simple list of supported platforms makes much more sense for the initial doc.
