### PR TITLE
Format Nix sources and update template lockfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,30 +46,7 @@ jobs:
         run: |
           ./scripts/check-templates.sh
 
-  build-example-dev-shells:
-    runs-on: ${{ matrix.systems.runner }}
-    needs: test
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      matrix:
-        systems:
-          - nix-system: aarch64-darwin
-            runner: macos-latest-xlarge
-          - nix-system: x86_64-darwin
-            runner: macos-latest-xlarge
-          - nix-system: x86_64-linux
-            runner: UbuntuLatest32Cores128G
-    steps:
-      - uses: actions/checkout@v5
-      - uses: DeterminateSystems/determinate-nix-action@main
-      - uses: DeterminateSystems/flakehub-cache-action@main
-
-      - name: Build example dev shells
-        run: ./scripts/build-example-dev-shells.sh
-
-  build-pkg-templates:
+  build-shells-and-templates:
     runs-on: ${{ matrix.systems.runner }}
     needs: test
     permissions:
@@ -88,6 +65,12 @@ jobs:
       - uses: actions/checkout@v5
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
+
+      - name: Build example dev shells
+        run: ./scripts/build-example-dev-shells.sh
+
+      - name: Build dev shells in templates
+        run: ./scripts/build-dev-templates.sh
 
       - name: Build packages in pkg templates
         run: ./scripts/build-pkg-templates.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check Nixpkgs input
         uses: DeterminateSystems/flake-checker-action@main
         with:
@@ -62,7 +62,7 @@ jobs:
           - nix-system: x86_64-linux
             runner: UbuntuLatest32Cores128G
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
 
@@ -85,7 +85,7 @@ jobs:
           - nix-system: x86_64-linux
             runner: UbuntuLatest32Cores128G
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
 

--- a/.github/workflows/flakehub-cache.yml
+++ b/.github/workflows/flakehub-cache.yml
@@ -20,7 +20,7 @@ jobs:
           - nix-system: x86_64-linux
             runner: UbuntuLatest32Cores128G
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Build dev shell for ${{ matrix.systems.nix-system }} on ${{ matrix.systems.runner }}

--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-push@main
         with:

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: DeterminateSystems/determinate-nix-action@v3
       - uses: DeterminateSystems/update-flake-lock@main
         with:
-          pr-title: "Update Nix flake inputs" # Title of PR to be created
+          pr-title: "Update root Nix flake inputs" # Title of PR to be created
           pr-labels: | # Labels to be set on the PR
             dependencies
             automated

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -3,7 +3,7 @@ name: "Flake.lock: update Nix dependencies"
 on:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: "0 0 * * 0" # runs weekly on Sunday at 00:00
+    - cron: "30 1 1,15 * *" # runs roughly every two weeks
 
 jobs:
   nix-flake-update:
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: DeterminateSystems/determinate-nix-action@v3
       - uses: DeterminateSystems/update-flake-lock@main
         with:
@@ -22,3 +22,48 @@ jobs:
           pr-labels: | # Labels to be set on the PR
             dependencies
             automated
+
+  nix-flake-update-templates:
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Update template flake.lock files
+        id: update
+        run: |
+          ./scripts/update-template-inputs.sh
+      - name: Detect potential changes
+        run: |
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create pull request for changes
+        if: ${{ steps.update.outputs.changed == 'true' }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: main
+          branch: flake-template-input-update
+          delete-branch: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "[Automated] Update template flake inputs"
+          commit-message: "Every-other-weekly template flake input update"
+          committer: github-actions[bot] github-actions[bot]@users.noreply.github.com
+          assignees: lucperkins
+          reviewers: lucperkins
+          labels:
+            automated
+            templates
+            update
+          body: |
+            This PR was created by an automated process that updates the flake inputs for the various flake
+            templates in Zero to Nix.
+
+            You can see the logic behind this in `.github/workflows/update-flake-lock.yml`.

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           ./scripts/update-template-inputs.sh
       - name: Detect potential changes
+        id: detect-changes
         run: |
           if git diff --quiet && git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -46,7 +47,7 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Create pull request for changes
-        if: ${{ steps.update.outputs.changed == 'true' }}
+        if: ${{ steps.detect-changes.outputs.changed == 'true' }}
         uses: peter-evans/create-pull-request@v7
         with:
           base: main

--- a/flake.nix
+++ b/flake.nix
@@ -10,19 +10,20 @@
     }:
 
     let
-      # Systems supported
-      allSystems = [
+      # Nix systems supported
+      supportedSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
         "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 
-      forAllSystems =
+      forEachSupportedSystem =
         f:
-        nixpkgs.lib.genAttrs allSystems (
+        nixpkgs.lib.genAttrs supportedSystems (
           system:
           f {
+            inherit system;
             pkgs = import nixpkgs { inherit system; };
           }
         );
@@ -31,8 +32,8 @@
       runPkg = pkgs: pkg: "${pkgs.${pkg}}/bin/${pkg}";
     in
     {
-      devShells = forAllSystems (
-        { pkgs }:
+      devShells = forEachSupportedSystem (
+        { pkgs, system }:
         let
           common = with pkgs; [
             # Language
@@ -136,7 +137,7 @@
         }
       );
 
-      formatter = forAllSystems ({ pkgs }: pkgs.nixfmt-rfc-style);
+      formatter = forEachSupportedSystem ({ pkgs, ... }: pkgs.nixfmt-rfc-style);
 
       templates = {
         cpp-dev = {

--- a/nix/shell/example.nix
+++ b/nix/shell/example.nix
@@ -4,7 +4,11 @@
   example = pkgs.mkShell {
     name = "zero-to-nix";
 
-    packages = with pkgs; [ curl jq git ];
+    packages = with pkgs; [
+      curl
+      jq
+      git
+    ];
 
     FUNNY_JOKE = "What kind of phone does a turtle use? A shell phone!";
   };
@@ -18,7 +22,10 @@
   };
 
   cpp = pkgs.mkShell {
-    packages = with pkgs; [ gcc cmake ];
+    packages = with pkgs; [
+      gcc
+      cmake
+    ];
 
     shellHook = ''
       echo "Welcome to a Nix development environment for C++!"
@@ -26,7 +33,10 @@
   };
 
   haskell = pkgs.mkShell {
-    packages = with pkgs.haskellPackages; [ stack ghc ];
+    packages = with pkgs.haskellPackages; [
+      stack
+      ghc
+    ];
 
     shellHook = ''
       echo "Welcome to a Nix development environment for Haskell!"
@@ -58,7 +68,10 @@
   };
 
   rust = pkgs.mkShell {
-    packages = with pkgs; [ cargo rustc ];
+    packages = with pkgs; [
+      cargo
+      rustc
+    ];
 
     shellHook = ''
       echo "Welcome to a Nix development environment for Rust!"
@@ -74,7 +87,12 @@
   };
 
   multi = pkgs.mkShell {
-    packages = with pkgs; [ python313 kubectl openssl opentofu ];
+    packages = with pkgs; [
+      python313
+      kubectl
+      openssl
+      opentofu
+    ];
 
     shellHook = ''
       echo "Welcome to a very mixed Nix development environment!"

--- a/nix/shell/example.nix
+++ b/nix/shell/example.nix
@@ -52,7 +52,7 @@
   };
 
   python = pkgs.mkShell {
-    packages = with pkgs; [ python313 ];
+    packages = with pkgs; [ python3 ];
 
     shellHook = ''
       echo "Welcome to a Nix development environment for Python!"
@@ -88,7 +88,7 @@
 
   multi = pkgs.mkShell {
     packages = with pkgs; [
-      python313
+      python3
       kubectl
       openssl
       opentofu

--- a/nix/templates/dev/cpp/flake.lock
+++ b/nix/templates/dev/cpp/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/cpp/flake.lock
+++ b/nix/templates/dev/cpp/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/cpp/flake.nix
+++ b/nix/templates/dev/cpp/flake.nix
@@ -8,7 +8,8 @@
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -19,20 +20,28 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
       # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          # The Nix packages provided in the environment
-          packages = with pkgs; [
-            boost # The Boost libraries
-            gcc # The GNU Compiler Collection
-          ];
-        };
-      });
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            # The Nix packages provided in the environment
+            packages = with pkgs; [
+              boost # The Boost libraries
+              gcc # The GNU Compiler Collection
+            ];
+          };
+        }
+      );
     };
 }

--- a/nix/templates/dev/golang/flake.lock
+++ b/nix/templates/dev/golang/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/golang/flake.lock
+++ b/nix/templates/dev/golang/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/golang/flake.nix
+++ b/nix/templates/dev/golang/flake.nix
@@ -8,7 +8,8 @@
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -19,20 +20,28 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
       # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          # The Nix packages provided in the environment
-          packages = with pkgs; [
-            go # The Go CLI
-            gotools # Go tools like goimports, godoc, and others
-          ];
-        };
-      });
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            # The Nix packages provided in the environment
+            packages = with pkgs; [
+              go # The Go CLI
+              gotools # Go tools like goimports, godoc, and others
+            ];
+          };
+        }
+      );
     };
 }

--- a/nix/templates/dev/haskell/flake.lock
+++ b/nix/templates/dev/haskell/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/haskell/flake.lock
+++ b/nix/templates/dev/haskell/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/haskell/flake.nix
+++ b/nix/templates/dev/haskell/flake.nix
@@ -8,7 +8,8 @@
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -19,20 +20,28 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
       # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          # The Nix packages provided in the environment
-          packages = with pkgs.haskellPackages; [
-            stack
-            ghc
-          ];
-        };
-      });
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            # The Nix packages provided in the environment
+            packages = with pkgs.haskellPackages; [
+              stack
+              ghc
+            ];
+          };
+        }
+      );
     };
 }

--- a/nix/templates/dev/javascript/flake.lock
+++ b/nix/templates/dev/javascript/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/javascript/flake.lock
+++ b/nix/templates/dev/javascript/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/javascript/flake.nix
+++ b/nix/templates/dev/javascript/flake.nix
@@ -8,7 +8,8 @@
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -19,19 +20,27 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
       # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          # The Nix packages provided in the environment
-          packages = with pkgs; [
-            nodejs_20 # Node.js 20, plus npm, npx, and corepack
-          ];
-        };
-      });
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            # The Nix packages provided in the environment
+            packages = with pkgs; [
+              nodejs_20 # Node.js 20, plus npm, npx, and corepack
+            ];
+          };
+        }
+      );
     };
 }

--- a/nix/templates/dev/python/flake.lock
+++ b/nix/templates/dev/python/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/python/flake.lock
+++ b/nix/templates/dev/python/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/python/flake.nix
+++ b/nix/templates/dev/python/flake.nix
@@ -36,8 +36,8 @@
         {
           default =
             let
-              # Use Python 3.11
-              python = pkgs.python311;
+              # Use Python 3.*
+              python = pkgs.python3;
             in
             pkgs.mkShell {
               # The Nix packages provided in the environment

--- a/nix/templates/dev/python/flake.nix
+++ b/nix/templates/dev/python/flake.nix
@@ -8,7 +8,8 @@
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -19,28 +20,38 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
       # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default =
-          let
-            # Use Python 3.11
-            python = pkgs.python311;
-          in
-          pkgs.mkShell {
-            # The Nix packages provided in the environment
-            packages = [
-              # Python plus helper tools
-              (python.withPackages (ps: with ps; [
-                virtualenv # Virtualenv
-                pip # The pip installer
-              ]))
-            ];
-          };
-      });
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+          default =
+            let
+              # Use Python 3.11
+              python = pkgs.python311;
+            in
+            pkgs.mkShell {
+              # The Nix packages provided in the environment
+              packages = [
+                # Python plus helper tools
+                (python.withPackages (
+                  ps: with ps; [
+                    virtualenv # Virtualenv
+                    pip # The pip installer
+                  ]
+                ))
+              ];
+            };
+        }
+      );
     };
 }

--- a/nix/templates/dev/rust/flake.lock
+++ b/nix/templates/dev/rust/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -41,12 +41,12 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1758076341,
-        "narHash": "sha256-ZKi6pyRDw2/3xU7qxd+2+lneQXUOe92TiF+10DflolM=",
-        "rev": "562fb6f14678eb9b8a36829140f6a4d0737776d2",
-        "revCount": 1918,
+        "lastModified": 1758162771,
+        "narHash": "sha256-hdZpMep6Z1gbgg9piUZ0BNusI6ZJaptBw6PHSN/3GD0=",
+        "rev": "d0cabb6ae8f5b38dffaff9f4e6db57c0ae21d729",
+        "revCount": 1919,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/oxalica/rust-overlay/0.1.1918%2Brev-562fb6f14678eb9b8a36829140f6a4d0737776d2/01995586-4a03-7420-b56c-e857fb4e6ab1/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/oxalica/rust-overlay/0.1.1919%2Brev-d0cabb6ae8f5b38dffaff9f4e6db57c0ae21d729/01995aac-f3ef-707a-b941-22154b334820/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/rust/flake.lock
+++ b/nix/templates/dev/rust/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -16,11 +16,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -41,12 +41,12 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742956365,
-        "narHash": "sha256-Slrqmt6kJ/M7Z/ce4ebQWsz2aeEodrX56CsupOEPoz0=",
-        "rev": "a0e3395c63cdbc9c1ec17915f8328c077c79c4a1",
-        "revCount": 1731,
+        "lastModified": 1758076341,
+        "narHash": "sha256-ZKi6pyRDw2/3xU7qxd+2+lneQXUOe92TiF+10DflolM=",
+        "rev": "562fb6f14678eb9b8a36829140f6a4d0737776d2",
+        "revCount": 1918,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/oxalica/rust-overlay/0.1.1731%2Brev-a0e3395c63cdbc9c1ec17915f8328c077c79c4a1/0195d04d-6657-7f5d-b555-b4c5cd83cf6d/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/oxalica/rust-overlay/0.1.1918%2Brev-562fb6f14678eb9b8a36829140f6a4d0737776d2/01995586-4a03-7420-b56c-e857fb4e6ab1/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/rust/flake.nix
+++ b/nix/templates/dev/rust/flake.nix
@@ -10,7 +10,12 @@
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs, rust-overlay }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+    }:
     let
       # Overlays enable you to customize the Nixpkgs attribute set
       overlays = [
@@ -32,21 +37,31 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit overlays system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit overlays system; };
+          }
+        );
     in
     {
       # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          # The Nix packages provided in the environment
-          packages = (with pkgs; [
-            # The package provided by our custom overlay. Includes cargo, Clippy, cargo-fmt,
-            # rustdoc, rustfmt, and other tools.
-            rustToolchain
-          ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ libiconv ]);
-        };
-      });
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            # The Nix packages provided in the environment
+            packages =
+              (with pkgs; [
+                # The package provided by our custom overlay. Includes cargo, Clippy, cargo-fmt,
+                # rustdoc, rustfmt, and other tools.
+                rustToolchain
+              ])
+              ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ libiconv ]);
+          };
+        }
+      );
     };
 }

--- a/nix/templates/dev/scala/flake.lock
+++ b/nix/templates/dev/scala/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/scala/flake.lock
+++ b/nix/templates/dev/scala/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/dev/scala/flake.nix
+++ b/nix/templates/dev/scala/flake.nix
@@ -8,17 +8,22 @@
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Overlays enable you to customize the Nixpkgs attribute set
       overlays = [
-        (final: prev:
-          let jdk = prev.openjdk17; in
+        (
+          final: prev:
+          let
+            jdk = prev.openjdk17;
+          in
           # sets jre/jdk overrides that use the openjdk17 package
           {
             jre = jdk;
             inherit jdk;
-          })
+          }
+        )
       ];
 
       # Systems supported
@@ -30,20 +35,28 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit overlays system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit overlays system; };
+          }
+        );
     in
     {
       # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          # The Nix packages provided in the environment
-          packages = with pkgs; [
-            # Uses the JRE/JDK version set up by the overlay.
-            sbt
-          ];
-        };
-      });
+      devShells = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            # The Nix packages provided in the environment
+            packages = with pkgs; [
+              # Uses the JRE/JDK version set up by the overlay.
+              sbt
+            ];
+          };
+        }
+      );
     };
 }

--- a/nix/templates/pkg/cpp/flake.lock
+++ b/nix/templates/pkg/cpp/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/cpp/flake.lock
+++ b/nix/templates/pkg/cpp/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/cpp/flake.nix
+++ b/nix/templates/pkg/cpp/flake.nix
@@ -6,7 +6,8 @@
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -17,27 +18,39 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
-      packages = forAllSystems ({ pkgs }: {
-        default =
-          let
-            binName = "zero-to-nix-cpp";
-            cppDependencies = with pkgs; [ boost gcc poco ];
-          in
-          pkgs.stdenv.mkDerivation {
-            name = "zero-to-nix-cpp";
-            src = self;
-            buildInputs = cppDependencies;
-            buildPhase = "c++ -std=c++17 -o ${binName} ${./main.cpp} -lPocoFoundation -lboost_system";
-            installPhase = ''
-              mkdir -p $out/bin
-              cp ${binName} $out/bin/
-            '';
-          };
-      });
+      packages = forAllSystems (
+        { pkgs }:
+        {
+          default =
+            let
+              binName = "zero-to-nix-cpp";
+              cppDependencies = with pkgs; [
+                boost
+                gcc
+                poco
+              ];
+            in
+            pkgs.stdenv.mkDerivation {
+              name = "zero-to-nix-cpp";
+              src = self;
+              buildInputs = cppDependencies;
+              buildPhase = "c++ -std=c++17 -o ${binName} ${./main.cpp} -lPocoFoundation -lboost_system";
+              installPhase = ''
+                mkdir -p $out/bin
+                cp ${binName} $out/bin/
+              '';
+            };
+        }
+      );
     };
 }

--- a/nix/templates/pkg/golang/flake.lock
+++ b/nix/templates/pkg/golang/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745391562,
-        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
-        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
-        "revCount": 788136,
+        "lastModified": 1757745802,
+        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
+        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
+        "revCount": 861038,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.788136%2Brev-8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7/019666b0-bb20-78ff-bdc8-39c1e789baac/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.861038%2Brev-c23193b943c6c689d70ee98ce3128239ed9e32d1/01994596-722e-716c-b0eb-e6b07d4de75b/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/golang/flake.lock
+++ b/nix/templates/pkg/golang/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757745802,
-        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
-        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
-        "revCount": 861038,
+        "lastModified": 1758035966,
+        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
+        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
+        "revCount": 862643,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.861038%2Brev-c23193b943c6c689d70ee98ce3128239ed9e32d1/01994596-722e-716c-b0eb-e6b07d4de75b/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.862643%2Brev-8d4ddb19d03c65a36ad8d189d001dc32ffb0306b/01995b50-95e4-7d71-b9c1-6826ce5699df/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/golang/flake.nix
+++ b/nix/templates/pkg/golang/flake.nix
@@ -5,7 +5,8 @@
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -16,19 +17,27 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
-      packages = forAllSystems ({ pkgs }: {
-        default = pkgs.buildGoModule {
-          name = "zero-to-nix-go";
-          src = self;
-          vendorHash = "sha256-JQ3vwk2F8aPy89I9E+phfUwCqe+ZeAJGPLpJ1ksiR18=";
-          goSum = ./go.sum;
-          subPackages = [ "cmd/zero-to-nix-go" ];
-        };
-      });
+      packages = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.buildGoModule {
+            name = "zero-to-nix-go";
+            src = self;
+            vendorHash = "sha256-JQ3vwk2F8aPy89I9E+phfUwCqe+ZeAJGPLpJ1ksiR18=";
+            goSum = ./go.sum;
+            subPackages = [ "cmd/zero-to-nix-go" ];
+          };
+        }
+      );
     };
 }

--- a/nix/templates/pkg/haskell/flake.lock
+++ b/nix/templates/pkg/haskell/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/haskell/flake.lock
+++ b/nix/templates/pkg/haskell/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/haskell/flake.nix
+++ b/nix/templates/pkg/haskell/flake.nix
@@ -6,7 +6,8 @@
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -17,21 +18,29 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
-      packages = forAllSystems ({ pkgs }: {
-        default = pkgs.haskellPackages.mkDerivation {
-          pname = "zero-to-nix-haskell";
-          version = "0.1.0";
-          src = self;
-          license = pkgs.lib.licenses.cc-by-sa-40;
-          executableHaskellDepends = with pkgs.haskellPackages; [
-            base
-          ];
-        };
-      });
+      packages = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.haskellPackages.mkDerivation {
+            pname = "zero-to-nix-haskell";
+            version = "0.1.0";
+            src = self;
+            license = pkgs.lib.licenses.cc-by-sa-40;
+            executableHaskellDepends = with pkgs.haskellPackages; [
+              base
+            ];
+          };
+        }
+      );
     };
 }

--- a/nix/templates/pkg/javascript/flake.lock
+++ b/nix/templates/pkg/javascript/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/javascript/flake.lock
+++ b/nix/templates/pkg/javascript/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/javascript/flake.nix
+++ b/nix/templates/pkg/javascript/flake.nix
@@ -47,10 +47,8 @@
             npmConfigHook = pkgs.importNpmLock.npmConfigHook;
 
             installPhase = ''
-              runHook preInstall
               mkdir -p "$out/share"
               cp -R dist/. "$out/share"/
-              runHook postInstall
             '';
           };
         }

--- a/nix/templates/pkg/javascript/flake.nix
+++ b/nix/templates/pkg/javascript/flake.nix
@@ -41,14 +41,16 @@
             src = self;
 
             npmDeps = pkgs.importNpmLock {
-              npmRoot = ./.;
+              npmRoot = self;
             };
 
             npmConfigHook = pkgs.importNpmLock.npmConfigHook;
 
             installPhase = ''
-              mkdir $out
-              cp dist/index.html $out
+              runHook preInstall
+              mkdir -p "$out/share"
+              cp -R dist/. "$out/share"/
+              runHook postInstall
             '';
           };
         }

--- a/nix/templates/pkg/javascript/flake.nix
+++ b/nix/templates/pkg/javascript/flake.nix
@@ -6,7 +6,8 @@
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -17,32 +18,40 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
-      packages = forAllSystems ({ pkgs }: {
-        default = pkgs.buildNpmPackage {
-          name = "zero-to-nix-javascript";
+      packages = forAllSystems (
+        { pkgs }:
+        {
+          default = pkgs.buildNpmPackage {
+            name = "zero-to-nix-javascript";
 
-          buildInputs = with pkgs; [
-            nodejs_latest
-          ];
+            buildInputs = with pkgs; [
+              nodejs_latest
+            ];
 
-          src = self;
+            src = self;
 
-          npmDeps = pkgs.importNpmLock {
-            npmRoot = ./.;
+            npmDeps = pkgs.importNpmLock {
+              npmRoot = ./.;
+            };
+
+            npmConfigHook = pkgs.importNpmLock.npmConfigHook;
+
+            installPhase = ''
+              mkdir $out
+              cp dist/index.html $out
+            '';
           };
-
-          npmConfigHook = pkgs.importNpmLock.npmConfigHook;
-
-          installPhase = ''
-            mkdir $out
-            cp dist/index.html $out
-          '';
-        };
-      });
+        }
+      );
     };
 }

--- a/nix/templates/pkg/python/flake.lock
+++ b/nix/templates/pkg/python/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/python/flake.lock
+++ b/nix/templates/pkg/python/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/python/flake.nix
+++ b/nix/templates/pkg/python/flake.nix
@@ -33,7 +33,7 @@
         {
           default =
             let
-              python = pkgs.python39;
+              python = pkgs.python3;
             in
             python.pkgs.buildPythonApplication {
               name = "zero-to-nix-python";

--- a/nix/templates/pkg/python/flake.nix
+++ b/nix/templates/pkg/python/flake.nix
@@ -6,7 +6,8 @@
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Systems supported
       allSystems = [
@@ -17,23 +18,31 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
-      packages = forAllSystems ({ pkgs }: {
-        default =
-          let
-            python = pkgs.python39;
-          in
-          python.pkgs.buildPythonApplication {
-            name = "zero-to-nix-python";
+      packages = forAllSystems (
+        { pkgs }:
+        {
+          default =
+            let
+              python = pkgs.python39;
+            in
+            python.pkgs.buildPythonApplication {
+              name = "zero-to-nix-python";
 
-            buildInputs = with python.pkgs; [ pip ];
+              buildInputs = with python.pkgs; [ pip ];
 
-            src = ./.;
-          };
-      });
+              src = ./.;
+            };
+        }
+      );
     };
 }

--- a/nix/templates/pkg/rust/flake.lock
+++ b/nix/templates/pkg/rust/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757941119,
-        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
-        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
-        "revCount": 809913,
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "revCount": 809980,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809980%2Brev-e9b7f2ff62b35f711568b1f0866243c7c302028d/01995913-45ee-7fa5-bb32-349ae394a9bb/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -41,12 +41,12 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1758076341,
-        "narHash": "sha256-ZKi6pyRDw2/3xU7qxd+2+lneQXUOe92TiF+10DflolM=",
-        "rev": "562fb6f14678eb9b8a36829140f6a4d0737776d2",
-        "revCount": 1918,
+        "lastModified": 1758162771,
+        "narHash": "sha256-hdZpMep6Z1gbgg9piUZ0BNusI6ZJaptBw6PHSN/3GD0=",
+        "rev": "d0cabb6ae8f5b38dffaff9f4e6db57c0ae21d729",
+        "revCount": 1919,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/oxalica/rust-overlay/0.1.1918%2Brev-562fb6f14678eb9b8a36829140f6a4d0737776d2/01995586-4a03-7420-b56c-e857fb4e6ab1/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/oxalica/rust-overlay/0.1.1919%2Brev-d0cabb6ae8f5b38dffaff9f4e6db57c0ae21d729/01995aac-f3ef-707a-b941-22154b334820/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/rust/flake.lock
+++ b/nix/templates/pkg/rust/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742751704,
-        "narHash": "sha256-rBfc+H1dDBUQ2mgVITMGBPI1PGuCznf9rcWX/XIULyE=",
-        "rev": "f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092",
-        "revCount": 716027,
+        "lastModified": 1757941119,
+        "narHash": "sha256-TssJZFzMRYdWgpHySzKv4YQg6DUv5SDENiWbVgNTo0M=",
+        "rev": "7ff837017c3b82bd3671932599a119d7bc672ff0",
+        "revCount": 809913,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.716027%2Brev-f0946fa5f1fb876a9dc2e1850d9d3a4e3f914092/0195c6e2-c99a-7cba-bb2f-adcbfb8b5c71/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.809913%2Brev-7ff837017c3b82bd3671932599a119d7bc672ff0/01995781-7c3c-753d-bf0b-06e4f23980f4/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -16,11 +16,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1681358109,
-        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -41,12 +41,12 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1742956365,
-        "narHash": "sha256-Slrqmt6kJ/M7Z/ce4ebQWsz2aeEodrX56CsupOEPoz0=",
-        "rev": "a0e3395c63cdbc9c1ec17915f8328c077c79c4a1",
-        "revCount": 1731,
+        "lastModified": 1758076341,
+        "narHash": "sha256-ZKi6pyRDw2/3xU7qxd+2+lneQXUOe92TiF+10DflolM=",
+        "rev": "562fb6f14678eb9b8a36829140f6a4d0737776d2",
+        "revCount": 1918,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/oxalica/rust-overlay/0.1.1731%2Brev-a0e3395c63cdbc9c1ec17915f8328c077c79c4a1/0195d04d-6657-7f5d-b555-b4c5cd83cf6d/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/oxalica/rust-overlay/0.1.1918%2Brev-562fb6f14678eb9b8a36829140f6a4d0737776d2/01995586-4a03-7420-b56c-e857fb4e6ab1/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/nix/templates/pkg/scala/flake.lock
+++ b/nix/templates/pkg/scala/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1675083208,
-        "narHash": "sha256-+sSFhSpV2jckr1qYlX/SaxQ6IdpagD6o4rru/3HAl0I=",
+        "lastModified": 1698464090,
+        "narHash": "sha256-Pnej7WZIPomYWg8f/CZ65sfW85IfIUjYhphMMg7/LT0=",
         "owner": "zaninime",
         "repo": "sbt-derivation",
-        "rev": "92d6d6d825e3f6ae5642d1cce8ff571c3368aaf7",
+        "rev": "6762cf2c31de50efd9ff905cbcc87239995a4ef9",
         "type": "github"
       },
       "original": {

--- a/nix/templates/pkg/scala/flake.nix
+++ b/nix/templates/pkg/scala/flake.nix
@@ -13,7 +13,13 @@
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs, sbt, ... }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      sbt,
+      ...
+    }:
     let
       name = "zero-to-nix-scala";
       version = "0.1.0";
@@ -28,43 +34,51 @@
       ];
 
       # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        inherit system;
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            inherit system;
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
     in
     {
       # Package outputs
-      packages = forAllSystems ({ pkgs, system }: {
-        default = sbt.mkSbtDerivation.${system} {
-          pname = name;
-          inherit version;
-          depsSha256 = "sha256-eOSvpVOMjIO+oUErei4NGj9xMKknhkFe6+NrUui+hm8=";
-          src = ./.;
-          depsWarmupCommand = ''
-            sbt 'managedClasspath; compilers'
-          '';
-          startScript = ''
-            #!${pkgs.runtimeShell}
+      packages = forAllSystems (
+        { pkgs, system }:
+        {
+          default = sbt.mkSbtDerivation.${system} {
+            pname = name;
+            inherit version;
+            depsSha256 = "sha256-eOSvpVOMjIO+oUErei4NGj9xMKknhkFe6+NrUui+hm8=";
+            src = ./.;
+            depsWarmupCommand = ''
+              sbt 'managedClasspath; compilers'
+            '';
+            startScript = ''
+              #!${pkgs.runtimeShell}
 
-            exec ${pkgs.openjdk_headless}/bin/java \
-              ''${JAVA_OPTS:-} \
-              -cp \
-              "${placeholder "out"}/share/${name}/lib/*" \
-              ${nixpkgs.lib.escapeShellArg mainClass} \
-              "$@"
-          '';
-          buildPhase = ''
-            sbt stage
-          '';
-          installPhase = ''
-            libs_dir="$out/share/${name}/lib"
-            mkdir -p "$libs_dir"
-            cp -ar target/universal/stage/lib/. "$libs_dir"
-            install -T -D -m755 $startScriptPath $out/bin/${name}
-          '';
-          passAsFile = [ "startScript" ];
-        };
-      });
+              exec ${pkgs.openjdk_headless}/bin/java \
+                ''${JAVA_OPTS:-} \
+                -cp \
+                "${placeholder "out"}/share/${name}/lib/*" \
+                ${nixpkgs.lib.escapeShellArg mainClass} \
+                "$@"
+            '';
+            buildPhase = ''
+              sbt stage
+            '';
+            installPhase = ''
+              libs_dir="$out/share/${name}/lib"
+              mkdir -p "$libs_dir"
+              cp -ar target/universal/stage/lib/. "$libs_dir"
+              install -T -D -m755 $startScriptPath $out/bin/${name}
+            '';
+            passAsFile = [ "startScript" ];
+          };
+        }
+      );
     };
 }

--- a/scripts/build-dev-templates.sh
+++ b/scripts/build-dev-templates.sh
@@ -1,0 +1,12 @@
+set -euo pipefail
+
+echo "Checking dev shell templates"
+
+SYSTEM=$(nix eval --raw --impure --expr builtins.currentSystem)
+
+echo "Building each individually"
+for shell in ./nix/templates/dev/*; do
+  echo "\_ building dev shell ${shell}"
+  nix build "${shell}#devShells.${SYSTEM}.default"
+  echo "\_ successfully built dev shell ${shell} ✅"
+done

--- a/scripts/build-dev-templates.sh
+++ b/scripts/build-dev-templates.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 echo "Checking dev shell templates"

--- a/scripts/build-example-dev-shells.sh
+++ b/scripts/build-example-dev-shells.sh
@@ -7,4 +7,5 @@ SYSTEM=$(nix eval --raw --impure --expr builtins.currentSystem)
 for shell in $(nix flake show --json --all-systems | jq -r ".devShells.\""${SYSTEM}\"" | keys[]"); do
   echo "\_ building shell ${shell}"
   nix build ".#devShells.${SYSTEM}.${shell}"
+  echo "\_ successfully built shell ${shell} ✅"
 done

--- a/scripts/build-example-dev-shells.sh
+++ b/scripts/build-example-dev-shells.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 echo "Checking example dev shells"

--- a/scripts/build-pkg-templates.sh
+++ b/scripts/build-pkg-templates.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 echo "Checking package build templates"

--- a/scripts/check-templates.sh
+++ b/scripts/check-templates.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 echo "Checking dev shell templates"

--- a/scripts/update-template-inputs.sh
+++ b/scripts/update-template-inputs.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 root=$(git rev-parse --show-toplevel)

--- a/scripts/update-template-inputs.sh
+++ b/scripts/update-template-inputs.sh
@@ -2,7 +2,7 @@ set -euo pipefail
 
 root=$(git rev-parse --show-toplevel)
 
-echo "Updating flake inputs for dev shell templates"
+echo "Updating flake inputs for dev and pkg templates"
 
 for kind in dev pkg; do
   for template in ${root}/nix/templates/${kind}/*; do
@@ -15,3 +15,5 @@ for kind in dev pkg; do
     )
   done
 done
+
+echo "Successfully updated flake inputs for all dev and pkg shell templates ✅"

--- a/scripts/update-template-inputs.sh
+++ b/scripts/update-template-inputs.sh
@@ -1,20 +1,17 @@
 set -euo pipefail
 
+root=$(git rev-parse --show-toplevel)
+
 echo "Updating flake inputs for dev shell templates"
 
-for template in ./nix/templates/dev/*; do
-  (
-    echo "\_ updating ${template}"
-    cd $template
-    nix flake update
-  )
-done
-
-echo "Updating flake inputs for package build templates"
-
-for template in ./nix/templates/pkg/*; do
-  (
-    cd $template
-    nix flake update
-  )
+for kind in dev pkg; do
+  for template in ${root}/nix/templates/${kind}/*; do
+    (
+      echo "\_ updating ${template}"
+      cd $template
+      nix flake update
+      nix flake check --all-systems
+      echo "\_ updated ${template} ✅"
+    )
+  done
 done

--- a/src/content/start/3.nix-develop.mdx
+++ b/src/content/start/3.nix-develop.mdx
@@ -401,7 +401,7 @@ type python
 You should see a (rather strange) path like this:
 
 ```shell title="Path information for Python"
-python is /nix/store/cqbfx55481irqgbl3bw8jwf69vjpbp8r-python3-3.11.9/bin/python
+python is /nix/store/a9mmam4km4bjnkzl62533w7d0wyrhrj9-python3-3.13.6/bin/python
 ```
 
 </SpecificLanguage>

--- a/src/content/start/3.nix-develop.mdx
+++ b/src/content/start/3.nix-develop.mdx
@@ -196,8 +196,6 @@ Now check the Go version:
 ```shell title="Check the Go version"
 go version
 ```
-
-You should get 1.22.5.
 </SpecificLanguage>
 <SpecificLanguage lang="Rust">
 ```shell title="Explore a development environment for Rust"

--- a/src/content/start/4.nix-build.mdx
+++ b/src/content/start/4.nix-build.mdx
@@ -318,7 +318,7 @@ Here's the package definition that enables us to build our Python package:
   packages = forAllSystems ({ pkgs }: {
     default =
       let
-        python = pkgs.python39;
+        python = pkgs.python3;
       in
       python.pkgs.buildPythonApplication {
         name = "zero-to-nix-python";

--- a/src/content/start/4.nix-build.mdx
+++ b/src/content/start/4.nix-build.mdx
@@ -307,7 +307,7 @@ For the full flake, see [`flake.nix`][flake-js] on GitHub or run `cat flake.nix`
 What you see here is a [derivation] that defines how to build the package, more specifically the `buildNpmPackage` function, which is a wrapper around Nix's built-in derivation function.
 
 The package that results when you run `nix build` is a website built using the [Vite] framework.
-To view that website, open the HTML file at `result/index.html`.
+To view that website, open the HTML file at `result/share/index.html`.
 
 </SpecificLanguage>
 <SpecificLanguage lang="Python">

--- a/src/content/start/4.nix-build.mdx
+++ b/src/content/start/4.nix-build.mdx
@@ -212,8 +212,8 @@ Here's the package definition that builds our C++ package:
         buildInputs = cppDependencies;
         buildPhase = "c++ -std=c++17 -o ${binName} ${./main.cpp} -lPocoFoundation -lboost_system";
         installPhase = ''
-          mkdir -p $out/bin
-          cp ${binName} $out/bin/
+          mkdir -p "$out/share"
+          cp -R dist/. "$out/share"/
         '';
       };
   });


### PR DESCRIPTION
Fixes #455 and creates an automatic update for every two weeks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-system dev shells/apps across Linux/macOS, new per-system formatter, unified shell scripts (setup/build/dev/format/check/lint/ci), and per-system example exports.

* **Documentation**
  * Default Python moved to Python 3 across snippets; removed a pinned Go version note; build/view paths updated.

* **Refactor/Style**
  * Large Nix template reformatting for per-system structure and readability (no behavioral regressions).

* **Chores / CI**
  * Template update script unified and improved; GitHub checkout upgraded to v5; new scheduled job to auto-update template flake inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->