### PR TITLE
Fix Markdown content negotiation

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -12,4 +12,6 @@ disable = [
   "MD046",
   # for some reason required for tables
   "MD058",
+  # indentations in lists
+  "MD077",
 ]

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,43 +3,48 @@ import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwind from "@astrojs/tailwind";
+import { defineConfig } from "astro/config";
 import expressiveCode from "astro-expressive-code";
 import icon from "astro-icon";
-import { defineConfig } from "astro/config";
 import rehypeExternalLinks from "rehype-external-links";
 import remarkEmoji from "remark-emoji";
 import remarkHeadingId from "remark-heading-id";
 
+const port = 3000;
+const site = process.env.ENV === "production"
+  ? "https://zero-to-nix.com"
+  : process.env.DEPLOY_PRIME_URL ?? `http://localhost:${port}`;
+
 export default defineConfig({
-  integrations: [
-    alpinejs({
-      entrypoint: "./src/entrypoint",
-    }),
-    expressiveCode(),
-    icon(),
-    mdx({
-      //gfm: true,
-      remarkPlugins: [remarkEmoji, remarkHeadingId],
-    }),
-    sitemap(),
-    tailwind(),
-    react(),
-  ],
-  markdown: {
-    rehypePlugins: [
-      [
-        rehypeExternalLinks,
-        { rel: ["nofollow noopener noreferrer"], target: "_blank" },
-      ],
-    ],
-  },
-  prefetch: {
-    prefetchAll: true,
-    defaultStrategy: "hover",
-  },
-  server: {
-    open: true,
-    port: 3000,
-  },
-  site: "https://zero-to-nix.com",
+	integrations: [
+		alpinejs({
+			entrypoint: "./src/entrypoint",
+		}),
+		expressiveCode(),
+		icon(),
+		mdx({
+			//gfm: true,
+			remarkPlugins: [remarkEmoji, remarkHeadingId],
+		}),
+		sitemap(),
+		tailwind(),
+		react(),
+	],
+	markdown: {
+		rehypePlugins: [
+			[
+				rehypeExternalLinks,
+				{ rel: ["nofollow noopener noreferrer"], target: "_blank" },
+			],
+		],
+	},
+	prefetch: {
+		prefetchAll: true,
+		defaultStrategy: "hover",
+	},
+	server: {
+		open: true,
+		port,
+	},
+	site,
 });

--- a/flake.lock
+++ b/flake.lock
@@ -2,12 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775423009,
-        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
-        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
-        "revCount": 975402,
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "revCount": 992384,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.975402%2Brev-68d8aa3d661f0e6bd5862291b5bb263b2a6595c9/019d657b-b3b7-7288-b3c0-42d420df206b/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.992384%2Brev-549bd84d6279f9852cae6225e372cc67fb91a4c1/019df915-70b5-73a2-a5a4-63c620b45d9f/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@ publish = "dist"
 # only want to run `npm ci`, which actually uses the `package-lock.json` lockfile.
 # Source: https://answers.netlify.com/t/how-can-i-use-npm-ci-instead-of-npm-install/12570/14
 NPM_FLAGS = "--version"
-NODE_VERSION = "24.13.0" # Keep this in step with `nix develop --command node --version`
+NODE_VERSION = "24.14.0" # Keep this in step with `nix develop --command node --version`
 
 [context.production]
 environment = { ENV = "production" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,10 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "rehype-external-links": "^3.0.0",
+        "remark": "^15.0.1",
         "remark-emoji": "^5.0.2",
         "remark-heading-id": "^1.0.1",
+        "strip-markdown": "^6.0.0",
         "typescript": "^5.9.3"
       },
       "devDependencies": {
@@ -8783,6 +8785,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
+      "integrity": "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-emoji": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-5.0.2.tgz",
@@ -9379,6 +9397,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-markdown": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-markdown/-/strip-markdown-6.0.0.tgz",
+      "integrity": "sha512-mSa8FtUoX3ExJYDkjPUTC14xaBAn4Ik5GPQD45G5E2egAmeV3kHgVSTfIoSDggbF6Pk9stahVgqsLCNExv6jHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/strnum": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "rehype-external-links": "^3.0.0",
+    "remark": "^15.0.1",
     "remark-emoji": "^5.0.2",
     "remark-heading-id": "^1.0.1",
+    "strip-markdown": "^6.0.0",
     "typescript": "^5.9.3"
   },
   "devDependencies": {

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -19,6 +19,10 @@ const { title: siteTitle, description: siteDescription } = site;
 
 const { title, description, tags, markdownNegotiation = false } = Astro.props;
 
+const plainDescription = description
+  ? (await plainText(description)).trim()
+  : siteDescription;
+
 const image = `${root}favicon.png`;
 ---
 
@@ -53,7 +57,7 @@ const image = `${root}favicon.png`;
 <SEO
   charset="utf-8"
   title={title ?? siteTitle}
-  description={description ? plainText(description) : siteDescription}
+  description={plainDescription}
   {canonical}
   openGraph={{
     basic: {
@@ -66,7 +70,7 @@ const image = `${root}favicon.png`;
   twitter={{
     site: root,
     title: title ?? siteTitle,
-    description,
+    description: plainDescription,
     image,
     card: "summary",
   }}

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -74,6 +74,16 @@ const image = `${root}favicon.png`;
     image,
     card: "summary",
   }}
+  extend={{
+    link: markdownNegotiation
+      ? [
+          {
+            rel: "alternate",
+            href: `${canonical.origin}${canonical.pathname.replace(/\/$/, "")}.md`,
+          },
+        ]
+      : [],
+  }}
 />
 
 <link
@@ -81,13 +91,3 @@ const image = `${root}favicon.png`;
   type="text/css"
   href="//cdn-images.mailchimp.com/embedcode/classic-071822.css"
 />
-
-{
-  markdownNegotiation && (
-    <link
-      rel="alternate"
-      type="text/markdown"
-      href={`${canonical.pathname.replace(/\/$/, "")}.md`}
-    />
-  )
-}

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -8,6 +8,7 @@ type Props = {
   description?: string;
   tags?: string[];
   author?: string;
+  markdownNegotiation?: boolean;
 };
 
 const root = Astro.site!.toString();
@@ -15,7 +16,7 @@ const canonical = new URL(Astro.url.pathname, root);
 
 const { title: siteTitle, description: siteDescription } = site;
 
-const { title, description, tags } = Astro.props;
+const { title, description, tags, markdownNegotiation = false } = Astro.props;
 
 const image = `${root}favicon.png`;
 ---
@@ -75,3 +76,9 @@ const image = `${root}favicon.png`;
   type="text/css"
   href="//cdn-images.mailchimp.com/embedcode/classic-071822.css"
 />
+
+{
+  markdownNegotiation && (
+    <link rel="alternate" type="text/markdown" href={`${canonical.href}.md`} />
+  )
+}

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,5 +1,6 @@
 ---
 import { SEO } from "astro-seo";
+import { plainText } from "../lib/utils";
 import { site } from "../site";
 import Posthog from "./Posthog.astro";
 
@@ -52,7 +53,7 @@ const image = `${root}favicon.png`;
 <SEO
   charset="utf-8"
   title={title ?? siteTitle}
-  description={description ?? siteDescription}
+  description={description ? plainText(description) : siteDescription}
   {canonical}
   openGraph={{
     basic: {
@@ -79,6 +80,10 @@ const image = `${root}favicon.png`;
 
 {
   markdownNegotiation && (
-    <link rel="alternate" type="text/markdown" href={`${canonical.href}.md`} />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      href={`${canonical.pathname.replace(/\/$/, "")}.md`}
+    />
   )
 }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,11 +10,12 @@ import { site } from "../site";
 type Props = {
   title?: string;
   description?: string;
+  markdownNegotiation?: boolean;
 };
 
 const { defaultLanguage } = site;
 
-const { title, description } = Astro.props;
+const { title, description, markdownNegotiation = false } = Astro.props;
 ---
 
 <html
@@ -22,7 +23,7 @@ const { title, description } = Astro.props;
   class="h-screen"
 >
   <head>
-    <Head {title} {description} />
+    <Head {title} {description} {markdownNegotiation} />
   </head>
   <body
     class="flex min-h-full flex-col bg-white font-sans text-dark antialiased dark:bg-dark dark:text-white"

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,6 @@
 import { marked } from "marked";
+import { remark } from "remark";
+import strip from 'strip-markdown';
 
 export const conceptPagePath = (slug: string): string => {
   return pagePath("concepts", slug);
@@ -10,6 +12,11 @@ export const md = async (md: string): Promise<string> => {
 
 export const startPagePath = (slug: string): string => {
   return pagePath("start", slug.substring(1));
+};
+
+export const plainText = async (md: string): Promise<string> => {
+  const file = await remark().use(strip).process(md);
+  return String(file).trim();
 };
 
 const pagePath = (collection: string, slug: string): string => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { marked } from "marked";
 import { remark } from "remark";
-import strip from 'strip-markdown';
+import strip from "strip-markdown";
 
 export const conceptPagePath = (slug: string): string => {
   return pagePath("concepts", slug);

--- a/src/pages/concepts/[slug].astro
+++ b/src/pages/concepts/[slug].astro
@@ -39,7 +39,7 @@ const relatedConceptPages: { title: string; href: string }[] = (
   });
 ---
 
-<Layout {title} description={snippet}>
+<Layout {title} description={snippet} markdownNegotiation>
   <HorizontalContainer>
     <Hero
       {title}

--- a/src/pages/start/[slug].astro
+++ b/src/pages/start/[slug].astro
@@ -36,7 +36,7 @@ const { Content } = await page.render();
 const numQuickStartPages = (await getStartPagesByOrderParam()).length;
 ---
 
-<Layout {title}>
+<Layout {title} markdownNegotiation>
   <HorizontalContainer>
     <Hero
       {title}

--- a/src/pages/start/[slug].md.ts
+++ b/src/pages/start/[slug].md.ts
@@ -5,12 +5,10 @@ export const prerender = true;
 
 type Props = { entry: CollectionEntry<"start"> };
 
-const stripExt = (id: string) => id.replace(/\.(md|mdx)$/i, "");
-
 export const getStaticPaths = (async () => {
   const entries = await getCollection("start");
   return entries.map((entry) => ({
-    params: { slug: stripExt(entry.id) },
+    params: { slug: entry.slug.substring(1) },
     props: { entry },
   }));
 }) satisfies GetStaticPaths;
@@ -19,7 +17,7 @@ export const GET: APIRoute<Props> = async ({ props, params }) => {
   let entry: CollectionEntry<"start"> | undefined = props?.entry;
   if (!entry && typeof params.slug === "string") {
     const all = await getCollection("start");
-    entry = all.find((e) => stripExt(e.id) === params.slug);
+    entry = all.find((e) => e.slug.substring(1) === params.slug);
   }
   if (!entry) {
     return new Response("Not Found", { status: 404 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Feature**
  * Optional markdown negotiation: pages can emit an alternate link to a markdown version when enabled.

* **Enhancement**
  * Page metadata descriptions are now normalized to plain text for SEO and social previews.
  * Layouts and pages can opt in to markdown negotiation so alternate-markdown links appear for enabled pages.

* **Refactor**
  * Slug handling for route resolution updated to a revised derivation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->