### PR TITLE
Remove x86_64-darwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,6 @@ jobs:
         systems:
           - nix-system: aarch64-darwin
             runner: macos-latest-xlarge
-          - nix-system: x86_64-darwin
-            runner: macos-latest-xlarge
           - nix-system: x86_64-linux
             runner: UbuntuLatest32Cores128G
     steps:

--- a/.github/workflows/flakehub-cache.yml
+++ b/.github/workflows/flakehub-cache.yml
@@ -15,8 +15,6 @@ jobs:
         systems:
           - nix-system: aarch64-darwin
             runner: macos-latest-xlarge
-          - nix-system: x86_64-darwin
-            runner: macos-latest-xlarge
           - nix-system: x86_64-linux
             runner: UbuntuLatest32Cores128G
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,6 @@
       supportedSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/dev/cpp/flake.nix
+++ b/nix/templates/dev/cpp/flake.nix
@@ -15,7 +15,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/dev/golang/flake.nix
+++ b/nix/templates/dev/golang/flake.nix
@@ -15,7 +15,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/dev/haskell/flake.nix
+++ b/nix/templates/dev/haskell/flake.nix
@@ -15,7 +15,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/dev/javascript/flake.nix
+++ b/nix/templates/dev/javascript/flake.nix
@@ -15,7 +15,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/dev/python/flake.nix
+++ b/nix/templates/dev/python/flake.nix
@@ -15,7 +15,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/dev/rust/flake.nix
+++ b/nix/templates/dev/rust/flake.nix
@@ -32,7 +32,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/dev/scala/flake.nix
+++ b/nix/templates/dev/scala/flake.nix
@@ -30,7 +30,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/pkg/cpp/flake.nix
+++ b/nix/templates/pkg/cpp/flake.nix
@@ -13,7 +13,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/pkg/golang/flake.nix
+++ b/nix/templates/pkg/golang/flake.nix
@@ -12,7 +12,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/pkg/haskell/flake.nix
+++ b/nix/templates/pkg/haskell/flake.nix
@@ -13,7 +13,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/pkg/javascript/flake.nix
+++ b/nix/templates/pkg/javascript/flake.nix
@@ -13,7 +13,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/pkg/python/flake.nix
+++ b/nix/templates/pkg/python/flake.nix
@@ -13,7 +13,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/pkg/rust/flake.nix
+++ b/nix/templates/pkg/rust/flake.nix
@@ -19,7 +19,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/nix/templates/pkg/scala/flake.nix
+++ b/nix/templates/pkg/scala/flake.nix
@@ -29,7 +29,6 @@
       allSystems = [
         "x86_64-linux" # 64-bit Intel/AMD Linux
         "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 

--- a/src/content/concepts/flakes.mdx
+++ b/src/content/concepts/flakes.mdx
@@ -243,7 +243,7 @@ You can also use Nix functions like this:
 {
   outputs = { self, nixpkgs }: let
     # The set of systems to provide outputs for
-    allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    allSystems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ];
 
     # A function that provides a system-specific Nixpkgs for the desired systems
     forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {

--- a/src/content/start/6.init-flake.mdx
+++ b/src/content/start/6.init-flake.mdx
@@ -37,8 +37,6 @@ git+file:///path/to/fh-init-example-project
 │   │   └───default: development environment 'nix-shell'
 │   ├───aarch64-linux
 │   │   └───default omitted (use '--all-systems' to show)
-│   ├───x86_64-darwin
-│   │   └───default omitted (use '--all-systems' to show)
 │   └───x86_64-linux
 │       └───default omitted (use '--all-systems' to show)
 └───schemas: unknown


### PR DESCRIPTION
Sad to see it go, but keeping these references in the tutorials is bound to mislead people.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated supported platform coverage to drop Intel-based macOS (`x86_64-darwin`) from generated development environments and formatter/package outputs; ARM-based macOS support remains available.
  * Adjusted CI build and caching matrices so macOS builds target the supported architecture only.
* **Documentation**
  * Refreshed flake output examples to match the reduced macOS coverage.
  * Cleaned up the “System specificity” Nix example to remove a duplicate architecture entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->