### PR TITLE
Fix missing space

### DIFF
--- a/src/components/Signup.astro
+++ b/src/components/Signup.astro
@@ -8,7 +8,7 @@ import SignupModal from "./SignupModal.astro";
   >
     <div class="items-center justify-between space-y-4 md:flex md:space-y-0">
       <h1 class="text-lg leading-snug font-light md:text-xl lg:text-2xl">
-        Stay up to date with what we're up to at
+        Stay up to date with what we're up to at 
         <span class="font-semibold">Determinate Systems</span>
       </h1>
 


### PR DESCRIPTION
There is a missing space in the callout to stay update to date with Determinate by signing up for our newsletter.
<img width="838" height="191" alt="Screenshot 2026-08-31 at 2 08 32 PM" src="https://github.com/user-attachments/assets/39197af3-e6c5-45a2-8bf7-0caafe4903d8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in the signup heading text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->