### PR TITLE
Update Signup.astro

### DIFF
--- a/src/components/Signup.astro
+++ b/src/components/Signup.astro
@@ -8,7 +8,7 @@ import SignupModal from "./SignupModal.astro";
   >
     <div class="items-center justify-between space-y-4 md:flex md:space-y-0">
       <h1 class="text-lg leading-snug font-light md:text-xl lg:text-2xl">
-        Stay up to date with what we're up to at 
+        Stay up to date with what we're up to at{" "}
         <span class="font-semibold">Determinate Systems</span>
       </h1>
 


### PR DESCRIPTION
Properly adding in the space this time, following Astro 7 whitespace handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spacing in the signup section so the sentence and bolded company name display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->